### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Flags:
   -r, --repo string           Name of the repository to export from Bitbucket Cloud
   -t, --token string          Bitbucket access token for authentication
   -u, --user string           Bitbucket username for basic authentication
-  -w, --workspace string      Bitbucket workspace (or username for personal accounts)
+  -w, --workspace string      Bitbucket workspace
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # gh-bbc-exporter
 
-A GitHub `gh` [CLI](https://cli.github.com/) extension for exporting BitBucket Cloud repositories into a format compatible with GitHub Enterprise migrations.
+A GitHub `gh` [CLI](https://cli.github.com/) extension for exporting Bitbucket Cloud repositories into a format compatible with GitHub Enterprise migrations.
 
 ## Overview
 
-This extension helps you migrate repositories from BitBucket Cloud to GitHub Enterprise Cloud by creating an export archive that matches the format expected by GHE migration tools.
+This extension helps you migrate repositories from Bitbucket Cloud to GitHub Enterprise Cloud by creating an export archive that matches the format expected by GHE migration tools.
 
 The exporter creates a complete migration archive containing:
 
@@ -16,11 +16,9 @@ The exporter creates a complete migration archive containing:
 
 ## Installation
 
-1. Install the `gh` CLI - see the [installation](https://github.com/cli/cli#installation) instructions.
-2. Install the extension:
-    ```sh
-    gh extension install katiem0/gh-bbc-exporter
-    ```
+```sh
+gh extension install katiem0/gh-bbc-exporter
+```
 
 For more information: [`gh extension install`](https://cli.github.com/manual/gh_extension_install).
 
@@ -28,30 +26,30 @@ For more information: [`gh extension install`](https://cli.github.com/manual/gh_
 ## Prerequisites
 
 - [GitHub CLI](https://cli.github.com/) installed and authenticated
-- BitBucket Cloud username and [app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) with repository read access
+- Bitbucket Cloud username and [app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/), or [Access Token](https://support.atlassian.com/bitbucket-cloud/docs/access-tokens/) with workspace administration access
 - Go 1.19 or higher (if building from source)
 
 ## Usage
 
-The `gh-bbc-exporter` extension only supports the retrievable of repositories from BitBucket Cloud:
+The `gh-bbc-exporter` extension only supports the retrievable of repositories from Bitbucket Cloud:
 
 ```sh
 gh bbc-exporter -h
-Export repository and metadata from BitBucket Cloud for GitHub Cloud import.
+Export repository and metadata from Bitbucket Cloud for GitHub Cloud import.
 
 Usage:
   bbc-exporter [flags]
 
 Flags:
-  -p, --app-password string   BitBucket app password for basic authentication
-  -a, --bbc-api-url string    BitBucket API to use (default "https://api.bitbucket.org/2.0")
+  -p, --app-password string   Bitbucket app password for basic authentication
+  -a, --bbc-api-url string    Bitbucket API to use (default "https://api.bitbucket.org/2.0")
   -d, --debug                 Enable debug logging
   -h, --help                  help for bbc-exporter
   -o, --output string         Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)
-  -r, --repo string           Name of the repository to export from BitBucket Cloud
-  -t, --token string          BitBucket access token for authentication
-  -u, --user string           BitBucket username for basic authentication
-  -w, --workspace string      BitBucket workspace (or username for personal accounts)
+  -r, --repo string           Name of the repository to export from Bitbucket Cloud
+  -t, --token string          Bitbucket access token for authentication
+  -u, --user string           Bitbucket username for basic authentication
+  -w, --workspace string      Bitbucket workspace (or username for personal accounts)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ For more information: [`gh extension install`](https://cli.github.com/manual/gh_
 
 ## Usage
 
-The `gh-bbc-exporter` extension only supports the retrievable of repositories from Bitbucket Cloud:
-
+The `gh-bbc-exporter` extension only supports the retrieval of repositories from Bitbucket Cloud:
 ```sh
 gh bbc-exporter -h
 Export repository and metadata from Bitbucket Cloud for GitHub Cloud import.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ func NewCmdRoot() *cobra.Command {
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketAppPass, "app-password", "p", "", "Bitbucket app password for basic authentication")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketAPIURL, "bbc-api-url", "a", "https://api.bitbucket.org/2.0", "Bitbucket API to use")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Repository, "repo", "r", "", "Name of the repository to export from Bitbucket Cloud")
-	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "", "Bitbucket workspace (or username for personal accounts)")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "", "Bitbucket workspace name")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.OutputDir, "output", "o", "", "Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)")
 	exportCmd.PersistentFlags().BoolVarP(&cmdFlags.Debug, "debug", "d", false, "Enable debug logging")
 	// Mark required flags


### PR DESCRIPTION
Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R7): Standardized the naming from "BitBucket Cloud" to "Bitbucket Cloud" throughout the document. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R52)

Command-line interface improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R52): Updated the prerequisites section to include Bitbucket Cloud access tokens and clarified the usage instructions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R52): Improved the descriptions of command-line flags for better clarity and consistency.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL53-R53): Modified the description of the `--workspace` flag to specify "Bitbucket workspace name" instead of "Bitbucket workspace (or username for personal accounts)".