### PR TITLE
Adding permissions for PR workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: PR Checks
 
-on: [ push, pull_request ]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ on:
       - '**.md'
       - '.github/workflows/release.yml'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     name: Build and Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,6 @@
 name: PR Checks
 
-on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - '.github/workflows/release.yml'
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - '.github/workflows/release.yml'
+on: [ push, pull_request ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Changes to branch and path filtering:

* Updated the `push` and `pull_request` triggers to use a more explicit YAML structure for specifying branches, removing the `paths-ignore` rules.

Changes to workflow permissions:

* Added explicit `permissions` for `contents: read` and `pull-requests: read` to ensure the workflow has the necessary access rights.


Closes #7 