### PR TITLE
Adding in open pr only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Flags:
   -a, --bbc-api-url string    Bitbucket API to use (default "https://api.bitbucket.org/2.0")
   -d, --debug                 Enable debug logging
   -h, --help                  help for bbc-exporter
+      --open-prs-only         Import only open pull requests and ignore closed/merged ones
   -o, --output string         Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)
   -r, --repo string           Name of the repository to export from Bitbucket Cloud
   -t, --token string          Bitbucket access token for authentication

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ func NewCmdRoot() *cobra.Command {
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Repository, "repo", "r", "", "Name of the repository to export from Bitbucket Cloud")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "", "Bitbucket workspace name")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.OutputDir, "output", "o", "", "Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)")
+	exportCmd.PersistentFlags().BoolVar(&cmdFlags.OpenPRsOnly, "open-prs-only", false, "Import only open pull requests and ignore closed/merged ones")
 	exportCmd.PersistentFlags().BoolVarP(&cmdFlags.Debug, "debug", "d", false, "Enable debug logging")
 	// Mark required flags
 	if err := exportCmd.MarkPersistentFlagRequired("workspace"); err != nil {
@@ -86,7 +87,7 @@ func runCmdExport(cmdFlags *data.CmdFlags, logger *zap.Logger) error {
 		cmdFlags.BitbucketAppPass,
 		logger,
 	)
-	exporter := utils.NewExporter(client, cmdFlags.OutputDir, logger)
+	exporter := utils.NewExporter(client, cmdFlags.OutputDir, logger, cmdFlags.OpenPRsOnly)
 
 	// Run export
 	if err := exporter.Export(cmdFlags.Workspace, cmdFlags.Repository); err != nil {

--- a/internal/data/bbdata.go
+++ b/internal/data/bbdata.go
@@ -8,6 +8,7 @@ type CmdFlags struct {
 	Repository       string
 	Workspace        string
 	OutputDir        string
+	OpenPRsOnly      bool
 	Debug            bool
 }
 

--- a/internal/utils/exporter.go
+++ b/internal/utils/exporter.go
@@ -16,16 +16,18 @@ import (
 )
 
 type Exporter struct {
-	client    *Client
-	outputDir string
-	logger    *zap.Logger
+	client      *Client
+	outputDir   string
+	logger      *zap.Logger
+	openPRsOnly bool
 }
 
-func NewExporter(client *Client, outputDir string, logger *zap.Logger) *Exporter {
+func NewExporter(client *Client, outputDir string, logger *zap.Logger, openPRsOnly bool) *Exporter {
 	return &Exporter{
-		client:    client,
-		outputDir: outputDir,
-		logger:    logger,
+		client:      client,
+		outputDir:   outputDir,
+		logger:      logger,
+		openPRsOnly: openPRsOnly,
 	}
 }
 
@@ -98,7 +100,7 @@ func (e *Exporter) Export(workspace, repoSlug string) error {
 		return err
 	}
 
-	prs, err := e.client.GetPullRequests(workspace, repoSlug)
+	prs, err := e.client.GetPullRequests(workspace, repoSlug, e.openPRsOnly)
 	if err != nil {
 		e.logger.Warn("Failed to fetch pull requests", zap.Error(err))
 		prs = []data.PullRequest{}

--- a/internal/utils/exporter_test.go
+++ b/internal/utils/exporter_test.go
@@ -18,7 +18,7 @@ import (
 func TestNewExporter(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	client := &Client{}
-	exporter := NewExporter(client, "output", logger)
+	exporter := NewExporter(client, "output", logger, false)
 
 	assert.NotNil(t, exporter)
 	assert.Equal(t, client, exporter.client)
@@ -29,7 +29,7 @@ func TestNewExporter(t *testing.T) {
 func TestCreateBasicUsers(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	client := &Client{}
-	exporter := NewExporter(client, "output", logger)
+	exporter := NewExporter(client, "output", logger, false)
 
 	users := exporter.createBasicUsers("testworkspace")
 
@@ -41,7 +41,7 @@ func TestCreateBasicUsers(t *testing.T) {
 func TestCreateOrganizationData(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	client := &Client{}
-	exporter := NewExporter(client, "output", logger)
+	exporter := NewExporter(client, "output", logger, false)
 
 	orgs := exporter.createOrganizationData("testworkspace")
 
@@ -61,7 +61,7 @@ func TestWriteJSONFile(t *testing.T) {
 
 	logger, _ := zap.NewDevelopment()
 	client := &Client{}
-	exporter := NewExporter(client, tempDir, logger)
+	exporter := NewExporter(client, tempDir, logger, false)
 
 	testData := []data.User{{
 		Type:  "user",
@@ -101,7 +101,7 @@ func TestCreateArchive(t *testing.T) {
 
 	logger, _ := zap.NewDevelopment()
 	client := &Client{}
-	exporter := NewExporter(client, tempDir, logger)
+	exporter := NewExporter(client, tempDir, logger, false)
 
 	dummyFilePath := filepath.Join(exporter.outputDir, "dummy.txt")
 	err = os.WriteFile(dummyFilePath, []byte("test data"), 0644)
@@ -145,7 +145,7 @@ func TestExport(t *testing.T) {
 		logger:         logger,
 		commitSHACache: make(map[string]string),
 	}
-	exporter := NewExporter(client, tempDir, logger)
+	exporter := NewExporter(client, tempDir, logger, false)
 
 	err = exporter.Export("workspace", "repo")
 	assert.NoError(t, err)


### PR DESCRIPTION
### Feature: Filter Pull Requests by State

* Added a new flag `--open-prs-only` to the command-line interface, allowing users to specify whether to import only open pull requests. This change is reflected in the `README.md` and `cmd/root.go` files. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R96) `cmd/root.go`: [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR51)
* Updated the `CmdFlags` struct to include the `OpenPRsOnly` boolean field, enabling the flag to be passed through the application. (`internal/data/bbdata.go`: [internal/data/bbdata.goR11](diffhunk://#diff-02b37770a886b8cbeea5496e279a6bd903fdde0f61ea9ac1f221f257a8745034R11))

### Core Logic Updates

* Modified the `GetPullRequests` method in the `Client` struct to accept the `openPRsOnly` parameter and adjust the API request accordingly. It now filters pull requests based on the specified state (`OPEN` or `ALL`). (`internal/utils/bitbucket.go`: [[1]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL263-R280) [[2]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL294-R309)
* Updated the `Exporter` struct and its `NewExporter` constructor to include the `openPRsOnly` field, ensuring the state filter is applied during the export process. (`internal/utils/exporter.go`: [[1]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fR22-R30) [[2]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fL101-R103)

### Test Enhancements

* Updated existing test cases for `GetPullRequests` and `Exporter` to include the new `openPRsOnly` parameter. (`internal/utils/bitbucket_test.go`: [[1]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L134-R135) [[2]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L147-R148) [[3]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L162-R163) `internal/utils/exporter_test.go`: [[4]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88L21-R21) [[5]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88L32-R32) [[6]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88L44-R44) [[7]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88L64-R64) [[8]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88L104-R104) [[9]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88L148-R148)
* Added a new test, `TestGetPullRequestsWithStateFilter`, to validate the behavior of the `GetPullRequests` method with both `openPRsOnly = true` and `openPRsOnly = false`. (`internal/utils/bitbucket_test.go`: [internal/utils/bitbucket_test.goR291-R337](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52R291-R337))