### PR TITLE
Adding logic to use repo slug since BB allows spaces in repo names

### DIFF
--- a/internal/data/bbdata.go
+++ b/internal/data/bbdata.go
@@ -14,6 +14,7 @@ type CmdFlags struct {
 
 type BitbucketRepository struct {
 	Name        string `json:"name"`
+	Slug        string `json:"slug"`
 	UUID        string `json:"uuid"`
 	FullName    string `json:"full_name"`
 	Owner       Owner  `json:"owner"`

--- a/internal/data/ghdata.go
+++ b/internal/data/ghdata.go
@@ -86,6 +86,7 @@ type Repository struct {
 	URL                    string                 `json:"url"`
 	Owner                  string                 `json:"owner"`
 	Name                   string                 `json:"name"`
+	Slug                   string                 `json:"slug"`
 	Description            string                 `json:"description"`
 	Private                bool                   `json:"private"`
 	HasIssues              bool                   `json:"has_issues"`

--- a/internal/utils/exporter.go
+++ b/internal/utils/exporter.go
@@ -32,7 +32,6 @@ func NewExporter(client *Client, outputDir string, logger *zap.Logger, openPRsOn
 }
 
 func (e *Exporter) Export(workspace, repoSlug string) error {
-
 	if e.outputDir == "" {
 		timestamp := time.Now().Format("20060102-150405")
 		e.outputDir = fmt.Sprintf("./bitbucket-export-%s", timestamp)

--- a/internal/utils/exporter.go
+++ b/internal/utils/exporter.go
@@ -32,6 +32,7 @@ func NewExporter(client *Client, outputDir string, logger *zap.Logger, openPRsOn
 }
 
 func (e *Exporter) Export(workspace, repoSlug string) error {
+
 	if e.outputDir == "" {
 		timestamp := time.Now().Format("20060102-150405")
 		e.outputDir = fmt.Sprintf("./bitbucket-export-%s", timestamp)
@@ -438,9 +439,10 @@ func (e *Exporter) createRepositoriesData(repo *data.BitbucketRepository, worksp
 	return []data.Repository{
 		{
 			Type:             "repository",
-			URL:              formatURL("repository", workspace, repo.Name),
+			URL:              formatURL("repository", workspace, repo.Slug),
 			Owner:            formatURL("user", workspace, ""),
 			Name:             repo.Name,
+			Slug:             repo.Slug,
 			Description:      repo.Description,
 			Private:          repo.IsPrivate,
 			HasIssues:        true,
@@ -450,7 +452,7 @@ func (e *Exporter) createRepositoriesData(repo *data.BitbucketRepository, worksp
 			Webhooks:         []interface{}{},
 			Collaborators:    []interface{}{},
 			CreatedAt:        createdAt,
-			GitURL:           formatURL("git", workspace, repo.Name),
+			GitURL:           formatURL("git", workspace, repo.Slug),
 			DefaultBranch:    "main",
 			PublicKeys:       []interface{}{},
 			Page:             nil,

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -234,24 +233,4 @@ func PrintSuccessMessage(outputPath string) {
 	} else {
 		fmt.Printf("\nExport successful!\nOutput directory: %s\n", outputPath)
 	}
-}
-
-// SanitizeRepositoryName converts a Bitbucket repository name to a GitHub-compatible format
-// by replacing spaces and non-alphanumeric characters with hyphens
-func SanitizeRepositoryName(name string) string {
-	// Replace spaces with hyphens
-	name = strings.ReplaceAll(name, " ", "-")
-
-	// Replace other non-alphanumeric characters (except hyphens and underscores) with hyphens
-	reg := regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
-	name = reg.ReplaceAllString(name, "-")
-
-	// Collapse multiple consecutive hyphens into a single one
-	reg = regexp.MustCompile(`-+`)
-	name = reg.ReplaceAllString(name, "-")
-
-	// Trim hyphens from start and end
-	name = strings.Trim(name, "-")
-
-	return name
 }

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -233,4 +234,24 @@ func PrintSuccessMessage(outputPath string) {
 	} else {
 		fmt.Printf("\nExport successful!\nOutput directory: %s\n", outputPath)
 	}
+}
+
+// SanitizeRepositoryName converts a Bitbucket repository name to a GitHub-compatible format
+// by replacing spaces and non-alphanumeric characters with hyphens
+func SanitizeRepositoryName(name string) string {
+	// Replace spaces with hyphens
+	name = strings.ReplaceAll(name, " ", "-")
+
+	// Replace other non-alphanumeric characters (except hyphens and underscores) with hyphens
+	reg := regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
+	name = reg.ReplaceAllString(name, "-")
+
+	// Collapse multiple consecutive hyphens into a single one
+	reg = regexp.MustCompile(`-+`)
+	name = reg.ReplaceAllString(name, "-")
+
+	// Trim hyphens from start and end
+	name = strings.Trim(name, "-")
+
+	return name
 }


### PR DESCRIPTION
### Repository Data Enhancements:
* Added a `Slug` field to the `BitbucketRepository` struct in `internal/data/bbdata.go` to represent repository slugs.
* Added a `Slug` field to the `Repository` struct in `internal/data/ghdata.go` to align with the new Bitbucket repository slug field.
* Updated the `createRepositoriesData` method in `internal/utils/exporter.go` to use the `Slug` field for `URL` and `GitURL` generation, replacing the previous use of the repository name. [[1]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fL441-R445) [[2]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fL453-R455)

### Utility Function Addition:
* Introduced a new `SanitizeRepositoryName` function in `internal/utils/helpers.go` to convert Bitbucket repository names into GitHub-compatible formats by replacing spaces and non-alphanumeric characters with hyphens, collapsing consecutive hyphens, and trimming hyphens from the start and end.
* Added a `regexp` package import in `internal/utils/helpers.go` to support the `SanitizeRepositoryName` function.