### PR TITLE
Adding `gh gei` commands to docs for import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ using GitHub owned storage and GEI. Detailed documentation can be found in
    If the repository can't be cloned, the exporter creates an empty repository structure.
    Check that the repository exists and is accessible.
 4. **Migration Fails in GitHub Enterprise Importer**
-   Check the error logging repository that's created during migration for detailed information about any failures.
+   Check the error logging repository that's created during migration for detailed
+   information about any failures.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ repositories into a format compatible with GitHub Enterprise migrations.
 ## Overview
 
 This extension helps you migrate repositories from Bitbucket Cloud to GitHub Enterprise Cloud
-by creating an export archive that matches the format expected by GHE migration tools.
+by creating an export archive that matches the format expected by GitHub Enterprise Importer (GEI).
 
 The exporter creates a complete migration archive containing:
 
@@ -101,6 +101,18 @@ Flags:
   -w, --workspace string      Bitbucket workspace
 ```
 
+Example Command
+
+```sh
+gh bbc-exporter -w your-workspace -r your-repo -t your-bitbucket-token
+```
+
+Or with basic authentication:
+
+```sh
+gh bbc-exporter -w your-workspace -r your-repo -u your-username -p your-app-password
+```
+
 For migrations from BitBucket Data Center or Server, please see [GitHub's Official Documentation](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/about-migrations-from-bitbucket-server-to-github-enterprise-cloud).
 
 ### Export Format
@@ -140,6 +152,8 @@ using GitHub owned storage and GEI. Detailed documentation can be found in
 - Issues are not exported (Bitbucket issues have a different structure from GitHub issues)
 - Repository and Pull request labels have not been implemented
 - User information is limited to what's available from Bitbucket API
+- Archives larger than 30 GiB are not supported by GitHub-owned storage
+- GitHub Enterprise Cloud with data residency is not supported
 
 ## Troubleshooting
 
@@ -153,6 +167,8 @@ using GitHub owned storage and GEI. Detailed documentation can be found in
 3. **Empty Repository Export**
    If the repository can't be cloned, the exporter creates an empty repository structure.
    Check that the repository exists and is accessible.
+4. **Migration Fails in GitHub Enterprise Importer**
+   Check the error logging repository that's created during migration for detailed information about any failures.
 
 ## Development
 

--- a/docs/GHImport.md
+++ b/docs/GHImport.md
@@ -6,7 +6,7 @@ This import process can utilize multiple storage options:
 2. AWS S3 Buckets
 3. [GitHub-owned storage (private preview)](https://github.blog/changelog/2024-11-21-migrate-repositories-with-github-enterprise-importer-using-github-owned-blob-storage-private-preview/)
 
-Each option provides a pathway for migrating Bitbucket Cloud repositories to 
+Each option provides a pathway for migrating Bitbucket Cloud repositories to
 GitHub Enterprise Cloud using the GitHub Enterprise Importer (GEI).
 
 > [!Note]
@@ -24,14 +24,13 @@ GitHub Enterprise Cloud using the GitHub Enterprise Importer (GEI).
 4. For usage of Azure Storage or AWS S3 with APIs directly, you must generate
    URLs for the archives that are accessible by GitHub through a short-lived URL.
 
-## Migration Options
 
-### Option 1: Using the GitHub CLI
+## Migrating with the GitHub CLI
 
-GitHub Enterprise Importer provides CLI commands that simplify the migration 
+GitHub Enterprise Importer provides CLI commands that simplify the migration
 process. This option works with both GitHub-owned storage and external storage providers.
 
-#### Using Azure Storage Blobs
+### Using Azure Storage Blobs
 
 For Azure Storage, you'll need to configure your [connection string](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-azure-blob-storage-account-credentials-in-the-github-cli)
 and then run:
@@ -47,9 +46,10 @@ gh gei migrate-repo \
   --metadata-archive-path AZURE_PATH.tar.gz
 ```
 
-#### Using AWS S3 Buckets
+### Using AWS S3 Buckets
 
-For AWS S3, you'll need to provide your [AWS credentials](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-aws-s3-credentials-in-the-github-cli) and then run:
+For AWS S3, you'll need to provide your
+[AWS credentials](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-aws-s3-credentials-in-the-github-cli) and then run:
 
 ```sh
 gh gei migrate-repo \
@@ -62,9 +62,10 @@ gh gei migrate-repo \
   --metadata-archive-path S3_PATH.tar.gz
 ```
 
-#### Using GitHub-owned storage
+### Using GitHub-owned storage
 
-If you have access to the [private preview of GitHub-owned storage](https://github.com/orgs/community/discussions/144948), use this command:
+If you have access to the
+[private preview of GitHub-owned storage](https://github.com/orgs/community/discussions/144948), use this command:
 
 ```sh
 gh gei migrate-repo \
@@ -77,15 +78,15 @@ gh gei migrate-repo \
   --use-github-storage
 ```
 
-### Option 2: Using GitHub-owned storage via individual API calls
+## Migrating with Individual API Calls
 
-#### Prerequisites
+### Prerequisites
 
 As noted in our public documentation, the same
 [recommendations and prerequisites](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=api#prerequisites)
 are needed for performing this migration.
 
-##### GitHub Enterprise Cloud Access
+### GitHub Enterprise Cloud Access
 
 As with other imports to GitHub, the ability to utilize
 [migrator or organization owner roles](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/managing-access-for-a-migration-from-bitbucket-server#required-roles-for-github)
@@ -95,7 +96,7 @@ Personal Access tokens will require different scopes based on the role. More
 information can be found in
 [Required scopes for personal access tokens](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/managing-access-for-a-migration-from-bitbucket-server#required-scopes-for-personal-access-tokens).
 
-#### Get Owner ID for Destination Organization
+### Get Owner ID for Destination Organization
 
 As an organization owner in GitHub Enterprise Cloud, use the `GetOrgInfo` query to
 return the `ownerId`, also called the organization ID, for the organization you
@@ -140,7 +141,7 @@ query(
 In this example, `MDEyOk9yZ2FuaXphdGlvbjU2MTA` is the organization ID or `ownerId`,
 which we'll use in the next step.
 
-#### Set Up Migration Source in GitHub Enterprise Cloud
+### Set Up Migration Source in GitHub Enterprise Cloud
 
 You can set up a migration source using the`createMigrationSource` query. You'll need to supply
 the `ownerId`, or organization ID, gathered from the `GetOrgInfo` query.
@@ -171,7 +172,7 @@ mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!) {
 | `url` | The URL for Bitbucket Cloud: `https://bitbucket.org` should be used. |
 <!-- markdownlint-enable MD013 -->
 
-### `createMigrationSource` response
+#### `createMigrationSource` response
 
 ```json
 {
@@ -191,12 +192,12 @@ mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!) {
 In this example, `MS_kgDaACRjZTY5NGQ1OC1mNDkyLTQ2NjgtOGE1NS00MGUxYTdlZmQwNWQ` is the migration
 source ID, which we'll use in a later step.
 
-#### Ensure Bitbucket Cloud Migration Archive exists
+### Ensure Bitbucket Cloud Migration Archive exists
 
 An archive should be accessible in the format `bitbucket-export-YYYYMMDD-HHMMSS.tar.gz` or
 another specified archive name.
 
-#### Upload Archive to GitHub-Owned Storage
+### Upload Archive to GitHub-Owned Storage
 
 Following documentation provided as part of the private preview for
 [(GEI) can migrate repositories with GitHub owned blob storage](https://github.com/orgs/community/discussions/144948).
@@ -207,7 +208,7 @@ migration, it may use one archive, or separate archives for Git data and reposit
 (i.e. pull requests, issues, etc.). In any case, perform the uploads as necessary, and keep
 track of the GEI URIs from your uploads to continue with a migration.
 
-##### Performing single uploads to GitHub-owned storage (step 7, <5 GiB)
+#### Performing single uploads to GitHub-owned storage (step 7, <5 GiB)
 
 To perform a single upload, simply submit a POST request with your archive as the POST data to:
 
@@ -267,7 +268,7 @@ The response body will include a JSON object, like so:
 The `"uri"` value contains the GEI URI! This URI represents the uploaded archive,
 and will be used to enqueue migrations in step 8!
 
-##### Performing multipart uploads to GitHub-owned storage (step 7, 5-30 GiB)
+#### Performing multipart uploads to GitHub-owned storage (step 7, 5-30 GiB)
 
 Multipart uploads are a little more involved, and follow a high-level flow like so:
 
@@ -336,7 +337,7 @@ Authorization: Bearer ghp_12345
 > Example of a Ruby script that will perform the above flow using Faraday and
 > Addressable can be found posted [here](https://github.com/orgs/community/discussions/144948).
 
-#### Start a Repository Migration
+### Start a Repository Migration
 
 When you start a migration, a single repository and its accompanying data
 migrates into a brand new GitHub repository that you identify.
@@ -386,7 +387,7 @@ mutation startRepositoryMigration (
 ```
 
 >[!Note]
-> If using GH-Owned storage, all GraphQL queries and mutations require 
+> If using GH-Owned storage, all GraphQL queries and mutations require
 > the private preview access GitHub-owned blob storage header added:
 >
 > ```graphql
@@ -418,7 +419,7 @@ The `getMigration` query will return with a status to let you know if the migrat
 `in progress`, `failed`, or `completed`. If your migration failed, the Importer will provide a reason
 for the failure.
 
-### `getMigration` query
+#### `getMigration` query
 
 ```graphql
 query (
@@ -439,7 +440,7 @@ query (
 ```
 
 >[!Note]
-> If using GH-Owned storage, all GraphQL queries and mutations require the 
+> If using GH-Owned storage, all GraphQL queries and mutations require the
 > private preview access header added:
 >
 > ```graphql

--- a/docs/GHImport.md
+++ b/docs/GHImport.md
@@ -24,7 +24,6 @@ GitHub Enterprise Cloud using the GitHub Enterprise Importer (GEI).
 4. For usage of Azure Storage or AWS S3 with APIs directly, you must generate
    URLs for the archives that are accessible by GitHub through a short-lived URL.
 
-
 ## Migrating with the GitHub CLI
 
 GitHub Enterprise Importer provides CLI commands that simplify the migration
@@ -49,7 +48,7 @@ gh gei migrate-repo \
 ### Using AWS S3 Buckets
 
 For AWS S3, you'll need to provide your
-[AWS credentials](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-aws-s3-credentials-in-the-github-cli) and then run:
+[AWS credentials](aws-credentials) and then run:
 
 ```sh
 gh gei migrate-repo \
@@ -470,3 +469,5 @@ to get your operations up and running. Additional post-migration steps that shou
 
 - [Accessing your migration logs](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/accessing-your-migration-logs-for-github-enterprise-importer)
 - [Reclaiming mannequins](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/reclaiming-mannequins-for-github-enterprise-importer)
+
+[aws-credentials]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-aws-s3-credentials-in-the-github-cli

--- a/docs/GHImport.md
+++ b/docs/GHImport.md
@@ -64,7 +64,7 @@ gh gei migrate-repo \
 ### Using GitHub-owned storage
 
 If you have access to the
-[private preview of GitHub-owned storage](https://github.com/orgs/community/discussions/144948), use this command:
+[private preview of GitHub-owned storage][private-storage], use this command:
 
 ```sh
 gh gei migrate-repo \
@@ -82,18 +82,17 @@ gh gei migrate-repo \
 ### Prerequisites
 
 As noted in our public documentation, the same
-[recommendations and prerequisites](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=api#prerequisites)
+[recommendations and prerequisites][recs-and-prereqs]
 are needed for performing this migration.
 
 ### GitHub Enterprise Cloud Access
 
 As with other imports to GitHub, the ability to utilize
-[migrator or organization owner roles](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/managing-access-for-a-migration-from-bitbucket-server#required-roles-for-github)
-still exists.
+[migrator or organization owner roles] [migrate-roles] still exists.
 
 Personal Access tokens will require different scopes based on the role. More
 information can be found in
-[Required scopes for personal access tokens](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/managing-access-for-a-migration-from-bitbucket-server#required-scopes-for-personal-access-tokens).
+[Required scopes for personal access tokens][PAT-scopes].
 
 ### Get Owner ID for Destination Organization
 
@@ -199,7 +198,7 @@ another specified archive name.
 ### Upload Archive to GitHub-Owned Storage
 
 Following documentation provided as part of the private preview for
-[(GEI) can migrate repositories with GitHub owned blob storage](https://github.com/orgs/community/discussions/144948).
+[(GEI) can migrate repositories with GitHub owned blob storage][private-stprage].
 
 There are two ways to upload your archives: single POST requests for archives up to 5 GiB,
 and via a multipart upload flow for archives between 5 MiB and 30 GiB. Depending on the
@@ -334,7 +333,7 @@ Authorization: Bearer ghp_12345
 
 > [!Note]
 > Example of a Ruby script that will perform the above flow using Faraday and
-> Addressable can be found posted [here](https://github.com/orgs/community/discussions/144948).
+> Addressable can be found posted [here][private-stprage].
 
 ### Start a Repository Migration
 
@@ -450,7 +449,7 @@ query (
 |:---------------|:------------|
 | `id` | The `id` that the `startRepositoryMigration` mutation returned. |
 
-Here are the possible values for [**`MigrationState`**](https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/enums#migrationstate)
+Here are the possible values for [**`MigrationState`**][migration-state]
 
 | Enumeration              | Description                                            |
 |:-------------------------|:-------------------------------------------------------|
@@ -467,8 +466,17 @@ Here are the possible values for [**`MigrationState`**](https://docs.github.com/
 Ensure the migrated resources are correctly setup and configure your workflows and CI/CD environments
 to get your operations up and running. Additional post-migration steps that should be completed:
 
-- [Accessing your migration logs](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/accessing-your-migration-logs-for-github-enterprise-importer)
-- [Reclaiming mannequins](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/reclaiming-mannequins-for-github-enterprise-importer)
+- [Accessing your migration logs][migration-logs]
+- [Reclaiming mannequins][reclaim-mannequin]
+
+<!-- link reference section -->
 
 [aws-credentials]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-aws-s3-credentials-in-the-github-cli
 [azure-string]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-azure-blob-storage-account-credentials-in-the-github-cli
+[private-stprage]: https://github.com/orgs/community/discussions/144948
+[recs-and-prereqs]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=api#prerequisites
+[migrate-roles]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/managing-access-for-a-migration-from-bitbucket-server#required-roles-for-github
+[PAT-scopes]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/managing-access-for-a-migration-from-bitbucket-server#required-scopes-for-personal-access-tokens
+[migration-state]: https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/enums#migrationstate
+[migration-logs]: https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/accessing-your-migration-logs-for-github-enterprise-importer
+[reclaim-mannequin]: https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/reclaiming-mannequins-for-github-enterprise-importer

--- a/docs/GHImport.md
+++ b/docs/GHImport.md
@@ -198,7 +198,7 @@ another specified archive name.
 ### Upload Archive to GitHub-Owned Storage
 
 Following documentation provided as part of the private preview for
-[(GEI) can migrate repositories with GitHub owned blob storage][private-stprage].
+[(GEI) can migrate repositories with GitHub owned blob storage][private-storage].
 
 There are two ways to upload your archives: single POST requests for archives up to 5 GiB,
 and via a multipart upload flow for archives between 5 MiB and 30 GiB. Depending on the
@@ -333,7 +333,7 @@ Authorization: Bearer ghp_12345
 
 > [!Note]
 > Example of a Ruby script that will perform the above flow using Faraday and
-> Addressable can be found posted [here][private-stprage].
+> Addressable can be found posted [here][private-storage].
 
 ### Start a Repository Migration
 
@@ -473,7 +473,7 @@ to get your operations up and running. Additional post-migration steps that shou
 
 [aws-credentials]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-aws-s3-credentials-in-the-github-cli
 [azure-string]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-azure-blob-storage-account-credentials-in-the-github-cli
-[private-stprage]: https://github.com/orgs/community/discussions/144948
+[private-storage]: https://github.com/orgs/community/discussions/144948
 [recs-and-prereqs]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=api#prerequisites
 [migrate-roles]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/managing-access-for-a-migration-from-bitbucket-server#required-roles-for-github
 [PAT-scopes]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/managing-access-for-a-migration-from-bitbucket-server#required-scopes-for-personal-access-tokens

--- a/docs/GHImport.md
+++ b/docs/GHImport.md
@@ -31,7 +31,7 @@ process. This option works with both GitHub-owned storage and external storage p
 
 ### Using Azure Storage Blobs
 
-For Azure Storage, you'll need to configure your [connection string](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-azure-blob-storage-account-credentials-in-the-github-cli)
+For Azure Storage, you'll need to configure your [connection string][azure-string]
 and then run:
 
 ```sh
@@ -48,7 +48,7 @@ gh gei migrate-repo \
 ### Using AWS S3 Buckets
 
 For AWS S3, you'll need to provide your
-[AWS credentials](aws-credentials) and then run:
+[AWS credentials][aws-credentials] and then run:
 
 ```sh
 gh gei migrate-repo \
@@ -471,3 +471,4 @@ to get your operations up and running. Additional post-migration steps that shou
 - [Reclaiming mannequins](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/reclaiming-mannequins-for-github-enterprise-importer)
 
 [aws-credentials]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-aws-s3-credentials-in-the-github-cli
+[azure-string]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud?tool=cli#configuring-azure-blob-storage-account-credentials-in-the-github-cli


### PR DESCRIPTION
### Updates to README:

* Updated terminology to refer to "GitHub Enterprise Importer (GEI)" instead of "GHE migration tools" for consistency.
* Added example commands for using the `gh bbc-exporter` CLI tool with both token-based and basic authentication.
* Noted new limitations: archives larger than 30 GiB and migrations to GitHub Enterprise Cloud with data residency are not supported.
* Added troubleshooting guidance for migration failures, including checking error logs created during the process.

### Updates to `docs/GHImport.md`:

* Expanded migration options to include Azure Storage Blobs, AWS S3 Buckets, and GitHub-owned storage, with detailed CLI commands for each.
* Clarified limitations, including archive size restrictions and data residency support, and added steps for generating short-lived URLs for external storage.
* Improved organization of sections by breaking down steps into smaller, more specific headings (e.g., "Get Owner ID for Destination Organization," "Start a Repository Migration"). [[1]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L40-R105) [[2]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L85-R148) [[3]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L290-R348)
* Added guidance for performing single and multipart uploads to GitHub-owned storage, including examples and notes about required headers for private preview features. [[1]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L152-R210) [[2]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L212-R270)
* Updated notes to clarify that all GraphQL queries and mutations require specific headers when using GitHub-owned storage in private preview. [[1]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L331-R390) [[2]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L384-R443)

Closes #16