### PR TITLE
Support Ability to Export PRs from given Date

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run tests
         run: |
           set -o pipefail
-          go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic 2>&1 | tee test_output.log
+          go test ./... -race -coverprofile=coverage.txt -covermode=atomic 2>&1 | tee test_output.log
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5.4.2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ output/
 
 *.log
 *.tmp
+
+coverage*

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,7 +11,7 @@ MD013:
   # Number of characters for code blocks
   code_block_line_length: 100
   # Include code blocks
-  code_blocks: true
+  code_blocks: false
   # Include tables
   tables: true
   # Include headings

--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-
 <!-- link reference section -->
 
 [app-password]: https://support.atlassian.com/bitbucket-cloud/docs/create-an-app-password/

--- a/README.md
+++ b/README.md
@@ -89,16 +89,17 @@ Usage:
   bbc-exporter [flags]
 
 Flags:
-  -p, --app-password string   Bitbucket app password for basic authentication
-  -a, --bbc-api-url string    Bitbucket API to use (default "https://api.bitbucket.org/2.0")
-  -d, --debug                 Enable debug logging
-  -h, --help                  help for bbc-exporter
-      --open-prs-only         Import only open pull requests and ignore closed/merged ones
-  -o, --output string         Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)
-  -r, --repo string           Name of the repository to export from Bitbucket Cloud
-  -t, --token string          Bitbucket access token for authentication
-  -u, --user string           Bitbucket username for basic authentication
-  -w, --workspace string      Bitbucket workspace
+  -p, --app-password string    Bitbucket app password for basic authentication
+  -a, --bbc-api-url string     Bitbucket API to use (default "https://api.bitbucket.org/2.0")
+  -d, --debug                  Enable debug logging
+  -h, --help                   help for bbc-exporter
+      --open-prs-only          Import only open pull requests and ignore closed/merged ones
+  -o, --output string          Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)
+      --prs-from-date string   Import pull requests created on or after this date (format: YYYY-MM-DD). Filters by PR creation date.
+  -r, --repo string            Name of the repository to export from Bitbucket Cloud
+  -t, --token string           Bitbucket access token for authentication
+  -u, --user string            Bitbucket username for basic authentication
+  -w, --workspace string       Bitbucket workspace name
 ```
 
 Example Command
@@ -152,7 +153,7 @@ using GitHub owned storage and GEI. Detailed documentation can be found in
 - Issues are not exported (Bitbucket issues have a different structure from GitHub issues)
 - Repository and Pull request labels have not been implemented
 - User information is limited to what's available from Bitbucket API
-- Archives larger than 30 GiB are not supported by GitHub-owned storage
+- [Archives larger than 40 GiB](https://github.blog/changelog/2025-06-03-increasing-github-enterprise-importers-repository-size-limits/) are not supported by GitHub-owned storage
 - GitHub Enterprise Cloud with data residency is not supported
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ are needed. Your Bitbucket username can be found by following:
 3. Click on "Settings"
 4. Find Username under **Bitbucket profile settings**
 
-To [create an app password](https://support.atlassian.com/bitbucket-cloud/docs/create-an-app-password/):
+To [create an app password][app-password]:
 
 1. Under Personal settings, select Personal Bitbucket settings.
 2. On the left sidebar, select App passwords.
@@ -114,7 +114,7 @@ Or with basic authentication:
 gh bbc-exporter -w your-workspace -r your-repo -u your-username -p your-app-password
 ```
 
-For migrations from BitBucket Data Center or Server, please see [GitHub's Official Documentation](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/about-migrations-from-bitbucket-server-to-github-enterprise-cloud).
+For migrations from BitBucket Data Center or Server, please see [GitHub's Official Documentation][bitbucket-server].
 
 ### Export Format
 
@@ -153,7 +153,7 @@ using GitHub owned storage and GEI. Detailed documentation can be found in
 - Issues are not exported (Bitbucket issues have a different structure from GitHub issues)
 - Repository and Pull request labels have not been implemented
 - User information is limited to what's available from Bitbucket API
-- [Archives larger than 40 GiB](https://github.blog/changelog/2025-06-03-increasing-github-enterprise-importers-repository-size-limits/) are not supported by GitHub-owned storage
+- [Archives larger than 40 GiB][storage-increase] are not supported by GitHub-owned storage
 - GitHub Enterprise Cloud with data residency is not supported
 
 ## Troubleshooting
@@ -210,3 +210,10 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 3. Commit your changes (`git commit -m 'Add some amazing feature'`)
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
+
+
+<!-- link reference section -->
+
+[app-password]: https://support.atlassian.com/bitbucket-cloud/docs/create-an-app-password/
+[storage-increase]: https://github.blog/changelog/2025-06-03-increasing-github-enterprise-importers-repository-size-limits/
+[bitbucket-server]: https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-from-bitbucket-server-to-github-enterprise-cloud/about-migrations-from-bitbucket-server-to-github-enterprise-cloud

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/katiem0/gh-bbc-exporter/internal/data"
 	"github.com/katiem0/gh-bbc-exporter/internal/utils"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,4 +20,88 @@ func TestValidateExportFlagsMixedAuth(t *testing.T) {
 	err := utils.ValidateExportFlags(cmdFlags)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "mixed authentication methods")
+}
+
+func TestPRFilteringFlagsIntegration(t *testing.T) {
+	// Create a new instance of the CmdFlags to capture the values
+	cmdFlags := &data.CmdFlags{}
+
+	// Create a test version of the command that uses our cmdFlags
+	cmd := &cobra.Command{
+		Run: func(cmd *cobra.Command, args []string) {
+			// This function will be called when cmd.Execute() runs
+		},
+	}
+
+	// Set up the flags the same way as in NewCmdRoot()
+	cmd.PersistentFlags().BoolVar(&cmdFlags.OpenPRsOnly, "open-prs-only", false, "Import only open pull requests")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.PRsFromDate, "prs-from-date", "", "", "Import pull requests created on or after this date")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "", "Bitbucket workspace name")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.Repository, "repo", "r", "", "Repository name")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketToken, "token", "t", "", "Token")
+
+	// Test 1: Open PRs only
+	args := []string{
+		"--workspace", "testworkspace",
+		"--repo", "testrepo",
+		"--token", "testtoken",
+		"--open-prs-only",
+	}
+
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	// Check that the cmdFlags has the right values
+	assert.True(t, cmdFlags.OpenPRsOnly, "Expected OpenPRsOnly to be true")
+	assert.Equal(t, "", cmdFlags.PRsFromDate, "Expected PRsFromDate to be empty")
+
+	// Test 2: PRs from date
+	cmdFlags = &data.CmdFlags{} // Reset flags
+	cmd = &cobra.Command{Run: func(cmd *cobra.Command, args []string) {}}
+	cmd.PersistentFlags().BoolVar(&cmdFlags.OpenPRsOnly, "open-prs-only", false, "Import only open pull requests")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.PRsFromDate, "prs-from-date", "", "", "Import pull requests created on or after this date")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "", "Bitbucket workspace name")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.Repository, "repo", "r", "", "Repository name")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketToken, "token", "t", "", "Token")
+
+	args = []string{
+		"--workspace", "testworkspace",
+		"--repo", "testrepo",
+		"--token", "testtoken",
+		"--prs-from-date", "2023-01-01",
+	}
+
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	assert.NoError(t, err)
+
+	// Check the values
+	assert.False(t, cmdFlags.OpenPRsOnly, "Expected OpenPRsOnly to be false")
+	assert.Equal(t, "2023-01-01", cmdFlags.PRsFromDate, "Expected PRsFromDate to be set")
+
+	// Test 3: Both filters
+	cmdFlags = &data.CmdFlags{} // Reset flags
+	cmd = &cobra.Command{Run: func(cmd *cobra.Command, args []string) {}}
+	cmd.PersistentFlags().BoolVar(&cmdFlags.OpenPRsOnly, "open-prs-only", false, "Import only open pull requests")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.PRsFromDate, "prs-from-date", "", "", "Import pull requests created on or after this date")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "", "Bitbucket workspace name")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.Repository, "repo", "r", "", "Repository name")
+	cmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketToken, "token", "t", "", "Token")
+
+	args = []string{
+		"--workspace", "testworkspace",
+		"--repo", "testrepo",
+		"--token", "testtoken",
+		"--open-prs-only",
+		"--prs-from-date", "2023-01-01",
+	}
+
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	assert.NoError(t, err)
+
+	// Check the values
+	assert.True(t, cmdFlags.OpenPRsOnly, "Expected OpenPRsOnly to be true")
+	assert.Equal(t, "2023-01-01", cmdFlags.PRsFromDate, "Expected PRsFromDate to be set")
 }

--- a/internal/data/bbdata.go
+++ b/internal/data/bbdata.go
@@ -8,6 +8,7 @@ type CmdFlags struct {
 	Repository       string
 	Workspace        string
 	OutputDir        string
+	PRsFromDate      string // Format: YYYY-MM-DD
 	OpenPRsOnly      bool
 	Debug            bool
 }

--- a/internal/utils/exporter.go
+++ b/internal/utils/exporter.go
@@ -20,14 +20,16 @@ type Exporter struct {
 	outputDir   string
 	logger      *zap.Logger
 	openPRsOnly bool
+	prsFromDate string
 }
 
-func NewExporter(client *Client, outputDir string, logger *zap.Logger, openPRsOnly bool) *Exporter {
+func NewExporter(client *Client, outputDir string, logger *zap.Logger, openPRsOnly bool, prsFromDate string) *Exporter {
 	return &Exporter{
 		client:      client,
 		outputDir:   outputDir,
 		logger:      logger,
 		openPRsOnly: openPRsOnly,
+		prsFromDate: prsFromDate,
 	}
 }
 
@@ -100,13 +102,15 @@ func (e *Exporter) Export(workspace, repoSlug string) error {
 		return err
 	}
 
-	prs, err := e.client.GetPullRequests(workspace, repoSlug, e.openPRsOnly)
+	prs, err := e.client.GetPullRequests(workspace, repoSlug, e.openPRsOnly, e.prsFromDate)
 	if err != nil {
 		e.logger.Warn("Failed to fetch pull requests", zap.Error(err))
 		prs = []data.PullRequest{}
 	} else {
 		e.logger.Info("Successfully fetched pull requests",
-			zap.Int("count", len(prs)))
+			zap.Int("count", len(prs)),
+			zap.Bool("open_only", e.openPRsOnly),
+			zap.String("from_date", e.prsFromDate))
 	}
 
 	if len(prs) > 0 {

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -224,6 +224,13 @@ func ValidateExportFlags(cmdFlags *data.CmdFlags) error {
 		return fmt.Errorf("mixed authentication methods: provide either token OR username/app-password, not both")
 	}
 
+	// Validate PRsFromDate format if provided
+	if cmdFlags.PRsFromDate != "" {
+		if _, err := time.Parse("2006-01-02", cmdFlags.PRsFromDate); err != nil {
+			return fmt.Errorf("invalid date format for --prs-from: %v (expected format: YYYY-MM-DD)", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -227,7 +227,7 @@ func ValidateExportFlags(cmdFlags *data.CmdFlags) error {
 	// Validate PRsFromDate format if provided
 	if cmdFlags.PRsFromDate != "" {
 		if _, err := time.Parse("2006-01-02", cmdFlags.PRsFromDate); err != nil {
-			return fmt.Errorf("invalid date format for --prs-from: %v (expected format: YYYY-MM-DD)", err)
+			return fmt.Errorf("invalid date format for --prs-from-date: %v (expected format: YYYY-MM-DD)", err)
 		}
 	}
 

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -14,10 +14,9 @@ import (
 )
 
 func TestValidateExportFlags(t *testing.T) {
-	cmdFlags := &data.CmdFlags{}
 
 	// Test case 1: No credentials provided
-	cmdFlags = &data.CmdFlags{}
+	cmdFlags := &data.CmdFlags{}
 	err := ValidateExportFlags(cmdFlags)
 	assert.Error(t, err, "Expected error when no credentials are provided")
 
@@ -64,7 +63,7 @@ func TestValidateExportFlags(t *testing.T) {
 	cmdFlags.PRsFromDate = "01/01/2023"
 	err = ValidateExportFlags(cmdFlags)
 	assert.Error(t, err, "Expected error with invalid date format")
-	assert.Contains(t, err.Error(), "invalid date format for --prs-from", "Error should mention invalid date format")
+	assert.Contains(t, err.Error(), "invalid date format for --prs-from-date", "Error should mention invalid date format")
 }
 
 func TestSetupEnvironmentCredentials(t *testing.T) {

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -17,15 +17,18 @@ func TestValidateExportFlags(t *testing.T) {
 	cmdFlags := &data.CmdFlags{}
 
 	// Test case 1: No credentials provided
+	cmdFlags = &data.CmdFlags{}
 	err := ValidateExportFlags(cmdFlags)
 	assert.Error(t, err, "Expected error when no credentials are provided")
 
 	// Test case 2: Token provided
+	cmdFlags = &data.CmdFlags{}
 	cmdFlags.BitbucketToken = "testtoken"
 	err = ValidateExportFlags(cmdFlags)
 	assert.NoError(t, err, "Expected no error when token is provided")
 
 	// Test case 3: Username and app password provided
+	cmdFlags = &data.CmdFlags{}
 	cmdFlags.BitbucketToken = ""
 	cmdFlags.BitbucketUser = "testuser"
 	cmdFlags.BitbucketAppPass = "testpass"
@@ -33,6 +36,7 @@ func TestValidateExportFlags(t *testing.T) {
 	assert.NoError(t, err, "Expected no error when username and app password are provided")
 
 	// Test case 4: Only username provided (missing app password)
+	cmdFlags = &data.CmdFlags{}
 	cmdFlags.BitbucketToken = ""
 	cmdFlags.BitbucketUser = "testuser"
 	cmdFlags.BitbucketAppPass = ""
@@ -40,11 +44,27 @@ func TestValidateExportFlags(t *testing.T) {
 	assert.Error(t, err, "Expected error when only username is provided")
 
 	// Test case 5: Only app password provided (missing username)
+	cmdFlags = &data.CmdFlags{}
 	cmdFlags.BitbucketToken = ""
 	cmdFlags.BitbucketUser = ""
 	cmdFlags.BitbucketAppPass = "testpass"
 	err = ValidateExportFlags(cmdFlags)
 	assert.Error(t, err, "Expected error when only app password is provided")
+
+	// Test case 6: Valid date format for PRsFromDate
+	cmdFlags = &data.CmdFlags{}
+	cmdFlags.BitbucketToken = "testtoken"
+	cmdFlags.PRsFromDate = "2023-01-01"
+	err = ValidateExportFlags(cmdFlags)
+	assert.NoError(t, err, "Expected no error with valid date format")
+
+	// Test case 7: Invalid date format for PRsFromDate
+	cmdFlags = &data.CmdFlags{}
+	cmdFlags.BitbucketToken = "testtoken"
+	cmdFlags.PRsFromDate = "01/01/2023"
+	err = ValidateExportFlags(cmdFlags)
+	assert.Error(t, err, "Expected error with invalid date format")
+	assert.Contains(t, err.Error(), "invalid date format for --prs-from", "Error should mention invalid date format")
 }
 
 func TestSetupEnvironmentCredentials(t *testing.T) {
@@ -341,7 +361,7 @@ func TestPaginationHandling(t *testing.T) {
 		commitSHACache: make(map[string]string),
 	}
 
-	prs, err := client.GetPullRequests("workspace", "repo", false)
+	prs, err := client.GetPullRequests("workspace", "repo", false, "")
 
 	assert.NoError(t, err)
 	assert.Len(t, prs, 2, "Expected PRs from both pages")
@@ -391,6 +411,63 @@ func TestExtractPRNumber(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := extractPRNumber(tc.prURL)
 			assert.Equal(t, tc.expected, result, "For URL %s, expected PR number %s but got %s", tc.prURL, tc.expected, result)
+		})
+	}
+}
+
+func TestPRDateValidation(t *testing.T) {
+	testCases := []struct {
+		name        string
+		dateStr     string
+		expectError bool
+	}{
+		{
+			name:        "Valid date format",
+			dateStr:     "2023-01-01",
+			expectError: false,
+		},
+		{
+			name:        "Invalid date format - slashes",
+			dateStr:     "01/01/2023",
+			expectError: true,
+		},
+		{
+			name:        "Invalid date format - month first",
+			dateStr:     "01-31-2023",
+			expectError: true,
+		},
+		{
+			name:        "Invalid date - nonexistent date",
+			dateStr:     "2023-02-30",
+			expectError: true,
+		},
+		{
+			name:        "Invalid date - text",
+			dateStr:     "yesterday",
+			expectError: true,
+		},
+		{
+			name:        "Empty string",
+			dateStr:     "",
+			expectError: false, // Empty is valid as it's optional
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmdFlags := &data.CmdFlags{
+				BitbucketToken: "test-token", // Add required auth
+				PRsFromDate:    tc.dateStr,
+			}
+
+			err := ValidateExportFlags(cmdFlags)
+
+			if tc.expectError {
+				assert.Error(t, err, "Expected error for date: %s", tc.dateStr)
+				assert.Contains(t, err.Error(), "invalid date format", "Error should mention date format")
+			} else {
+				assert.NoError(t, err, "Expected no error for date: %s", tc.dateStr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Pull Request Filtering Enhancements:
* Added a new flag `--prs-from-date` to filter pull requests based on their creation date. This flag accepts dates in `YYYY-MM-DD` format. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98-R102) `cmd/root.go` [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR52)
* Updated the `GetPullRequests` function in `internal/utils/bitbucket.go` to support filtering pull requests by creation date. This includes parsing the date and skipping pull requests created before the specified date. (`internal/utils/bitbucket.go` [[1]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dR275-R301) [[2]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dR376-R398)
* Enhanced logging to provide detailed information about filtering criteria and skipped pull requests. (`internal/utils/bitbucket.go` [[1]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dR275-R301) [[2]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dR376-R398)

### Codebase Updates:
* Modified the `CmdFlags` struct in `internal/data/bbdata.go` to include the `PRsFromDate` field for storing the filter date. (`internal/data/bbdata.go` [internal/data/bbdata.goR11](diffhunk://#diff-02b37770a886b8cbeea5496e279a6bd903fdde0f61ea9ac1f221f257a8745034R11))
* Updated related unit tests to validate the new filtering functionality, including integration tests for the `--prs-from-date` flag and tests for pull request filtering by date. (`cmd/root_test.go` [[1]](diffhunk://#diff-558a3da4e777c67907421d3d7da4d33b537fa8fba7c600b2938bb2d39fdb59faR24-R107) `internal/utils/bitbucket_test.go` [[2]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L381-R395) [[3]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L335-R300)

### Documentation Improvements:
* Clarified the description of the `--workspace` flag in the `README.md` to specify "Bitbucket workspace name." (`README.md` [README.mdR98-R102](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98-R102))
* Updated the documentation to reflect the increased GitHub Enterprise Importer repository size limit to 40 GiB. (`README.md` [README.mdL155-R156](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R156))


Closes #25 