### PR TITLE
Updating main context for correct language

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,7 +11,7 @@ MD013:
   # Number of characters for code blocks
   code_block_line_length: 100
   # Include code blocks
-  code_blocks: false
+  code_blocks: true
   # Include tables
   tables: true
   # Include headings

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Flags:
   -a, --bbc-api-url string     Bitbucket API to use (default "https://api.bitbucket.org/2.0")
   -d, --debug                  Enable debug logging
   -h, --help                   help for bbc-exporter
-      --open-prs-only          Import only open pull requests and ignore closed/merged ones
+      --open-prs-only          Export only open pull requests and ignore closed/merged ones
   -o, --output string          Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)
-      --prs-from-date string   Import pull requests created on or after this date (format: YYYY-MM-DD). Filters by PR creation date.
+      --prs-from-date string   Export pull requests created on or after this date (format: YYYY-MM-DD)
   -r, --repo string            Name of the repository to export from Bitbucket Cloud
   -t, --token string           Bitbucket access token for authentication
   -u, --user string            Bitbucket username for basic authentication

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,8 +48,8 @@ func NewCmdRoot() *cobra.Command {
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Repository, "repo", "r", "", "Name of the repository to export from Bitbucket Cloud")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "", "Bitbucket workspace name")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.OutputDir, "output", "o", "", "Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)")
-	exportCmd.PersistentFlags().BoolVar(&cmdFlags.OpenPRsOnly, "open-prs-only", false, "Import only open pull requests and ignore closed/merged ones")
-	exportCmd.PersistentFlags().StringVarP(&cmdFlags.PRsFromDate, "prs-from-date", "", "", "Import pull requests created on or after this date (format: YYYY-MM-DD). Filters by PR creation date.")
+	exportCmd.PersistentFlags().BoolVar(&cmdFlags.OpenPRsOnly, "open-prs-only", false, "Export only open pull requests and ignore closed/merged ones")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.PRsFromDate, "prs-from-date", "", "", "Export pull requests created on or after this date (format: YYYY-MM-DD). Filters by PR creation date.")
 	exportCmd.PersistentFlags().BoolVarP(&cmdFlags.Debug, "debug", "d", false, "Enable debug logging")
 	// Mark required flags
 	if err := exportCmd.MarkPersistentFlagRequired("workspace"); err != nil {


### PR DESCRIPTION
### Documentation and Command-Line Flag Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R98): Updated flag descriptions to replace "Import" with "Export" for better alignment with the tool's functionality.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL51-R52): Adjusted descriptions of `--open-prs-only` and `--prs-from-date` flags to use "Export" instead of "Import" for consistency with the tool's purpose.

### Markdown Configuration Update:
* [`.markdownlint.yaml`](diffhunk://#diff-39aecbc26791dd03b9a4fdc1f856769ea73308294b7111d70f279ac9bdef35bdL14-R14): Enabled linting for code blocks by setting `code_blocks` to `true`.