### PR TITLE
Adding in logic for api tokens and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,36 @@ For more information: [`gh extension install`](https://cli.github.com/manual/gh_
 
 Bitbucket Cloud provides two authentication methods for their API:
 
-- Basic Authentication
-- Access Token (premium membership)
+- API Tokens (recommended)
+- Workspace Access Tokens (premium membership)
+- Basic Authentication with App Passwords (deprecated, will be discontinued after September 9, 2025)
 
-#### Basic Authentication
+#### API Tokens
+
+API tokens are the recommended authentication method and will replace app passwords.
+To create an API token:
+
+1. Log in to Bitbucket Cloud
+2. Click on your profile avatar in the top right
+3. Select **Atlassian account settings**
+4. In the top navigation section, select **Security**
+5. Click **Create and manage API tokens**
+6. Select **Create API token with scopes**
+7. Give your token a name and expiration date
+8. Select Bitbucket API token app and select the following permissions:
+   - `read:account`
+   - `read:pullrequest:bitbucket`
+   - `read:repository:bitbucket`
+   - `read:workspace:bitbucket`
+9. Click **Next**, review scopes and click **Create**
+10. Copy the token immediately as you won't be able to see it again
+
+#### Basic Authentication with App Passwords
+
+> [!Warning] 
+> App passwords will be discontinued after September 9, 2025. Creation of new app passwords
+> will stop after that date, and existing app passwords will stop working on June 9, 2026.
+> Please migrate to API tokens instead.
 
 For basic authentication with this tool your account username and an app password
 are needed. Your Bitbucket username can be found by following:
@@ -89,17 +115,19 @@ Usage:
   bbc-exporter [flags]
 
 Flags:
-  -p, --app-password string    Bitbucket app password for basic authentication (env: BITBUCKET_APP_PASSWORD)
   -a, --bbc-api-url string     Bitbucket API to use (default "https://api.bitbucket.org/2.0")
+  -t, --access-token string    Bitbucket workspace access token for authentication (env: BITBUCKET_ACCESS_TOKEN)
+      --api-token string       Bitbucket API token for authentication (env: BITBUCKET_API_TOKEN)
+  -e, --email string           Atlassian account email for API token authentication (env: BITBUCKET_EMAIL)
+  -u, --user string            Bitbucket username for basic authentication (env: BITBUCKET_USERNAME)
+  -p, --app-password string    Bitbucket app password for basic authentication (env: BITBUCKET_APP_PASSWORD)
+  -w, --workspace string       Bitbucket workspace name
+  -r, --repo string            Name of the repository to export from Bitbucket Cloud
+  -o, --output string          Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)
+      --open-prs-only          Export only open pull requests and ignore closed/merged ones
+      --prs-from-date string   Export pull requests created on or after this date (format: YYYY-MM-DD).
   -d, --debug                  Enable debug logging
   -h, --help                   help for bbc-exporter
-      --open-prs-only          Export only open pull requests and ignore closed/merged ones
-  -o, --output string          Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)
-      --prs-from-date string   Export pull requests created on or after this date (format: YYYY-MM-DD)
-  -r, --repo string            Name of the repository to export from Bitbucket Cloud
-  -t, --token string           Bitbucket access token for authentication (env: BITBUCKET_TOKEN)
-  -u, --user string            Bitbucket username for basic authentication (env: BITBUCKET_USERNAME)
-  -w, --workspace string       Bitbucket workspace name
 ```
 
 ### Authentication Methods
@@ -109,11 +137,16 @@ Flags:
 This tool supports the use of environment variables instead of command-line flags:
 
 ```sh
-# Token authentication
-export BITBUCKET_TOKEN="your-token-here"
+# API token authentication with email (recommended)
+export BITBUCKET_API_TOKEN="your-api-token-here"
+export BITBUCKET_EMAIL="your-atlassian-email@example.com"
 gh bbc-exporter -w your-workspace -r your-repo
 
-# Basic authentication
+# Workspace token authentication
+export BITBUCKET_ACCESS_TOKEN="your-workspace-token-here"
+gh bbc-exporter -w your-workspace -r your-repo
+
+# Basic authentication (soon to be deprecated)
 export BITBUCKET_USERNAME="your-username"
 export BITBUCKET_APP_PASSWORD="your-app-password"
 gh bbc-exporter -w your-workspace -r your-repo
@@ -124,12 +157,13 @@ gh bbc-exporter -w your-workspace -r your-repo
 Example Command
 
 ```sh
-gh bbc-exporter -w your-workspace -r your-repo -t your-bitbucket-token
-```
+# Using API token with email (recommended)
+gh bbc-exporter -w your-workspace -r your-repo --api-token your-api-token --email your-atlassian-email@example.com
 
-Or with basic authentication:
+# Using workspace access token
+gh bbc-exporter -w your-workspace -r your-repo -t your-workspace-token
 
-```sh
+# Using basic authentication (soon to be deprecated)
 gh bbc-exporter -w your-workspace -r your-repo -u your-username -p your-app-password
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,18 +45,28 @@ func NewCmdRoot() *cobra.Command {
 	exportCmd.PersistentFlags().SortFlags = false
 
 	// Configure flags for command
-	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketAPIURL, "bbc-api-url", "a", "https://api.bitbucket.org/2.0", "Bitbucket API to use")
-	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketToken, "token", "t", "",
-		"Bitbucket access token for authentication (env: BITBUCKET_TOKEN)")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketAPIURL, "bbc-api-url", "a",
+		"https://api.bitbucket.org/2.0", "Bitbucket API to use")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketAccessToken, "access-token", "t", "",
+		"Bitbucket workspace access token for authentication (env: BITBUCKET_ACCESS_TOKEN)")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketAPIToken, "api-token", "", "",
+		"Bitbucket API token for authentication (env: BITBUCKET_API_TOKEN)")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketEmail, "email", "e", "",
+		"Atlassian account email for API token authentication (env: BITBUCKET_EMAIL)")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketUser, "user", "u", "",
 		"Bitbucket username for basic authentication (env: BITBUCKET_USERNAME)")
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.BitbucketAppPass, "app-password", "p", "",
 		"Bitbucket app password for basic authentication (env: BITBUCKET_APP_PASSWORD)")
-	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "", "Bitbucket workspace name")
-	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Repository, "repo", "r", "", "Name of the repository to export from Bitbucket Cloud")
-	exportCmd.PersistentFlags().StringVarP(&cmdFlags.OutputDir, "output", "o", "", "Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)")
-	exportCmd.PersistentFlags().BoolVar(&cmdFlags.OpenPRsOnly, "open-prs-only", false, "Export only open pull requests and ignore closed/merged ones")
-	exportCmd.PersistentFlags().StringVarP(&cmdFlags.PRsFromDate, "prs-from-date", "", "", "Export pull requests created on or after this date (format: YYYY-MM-DD).")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Workspace, "workspace", "w", "",
+		"Bitbucket workspace name")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.Repository, "repo", "r", "",
+		"Name of the repository to export from Bitbucket Cloud")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.OutputDir, "output", "o", "",
+		"Output directory for exported data (default: ./bitbucket-export-TIMESTAMP)")
+	exportCmd.PersistentFlags().BoolVar(&cmdFlags.OpenPRsOnly, "open-prs-only", false,
+		"Export only open pull requests and ignore closed/merged ones")
+	exportCmd.PersistentFlags().StringVarP(&cmdFlags.PRsFromDate, "prs-from-date", "", "",
+		"Export pull requests created on or after this date (format: YYYY-MM-DD).")
 	exportCmd.PersistentFlags().BoolVarP(&cmdFlags.Debug, "debug", "d", false, "Enable debug logging")
 	// Mark required flags
 	if err := exportCmd.MarkPersistentFlagRequired("workspace"); err != nil {
@@ -81,8 +91,10 @@ func runCmdExport(cmdFlags *data.CmdFlags, logger *zap.Logger) error {
 		return err
 	}
 
-	if cmdFlags.BitbucketToken != "" {
-		logger.Info("Using token authentication")
+	if cmdFlags.BitbucketAccessToken != "" {
+		logger.Info("Using workspace access token authentication")
+	} else if cmdFlags.BitbucketAPIToken != "" {
+		logger.Info("Using API token authentication")
 	} else if cmdFlags.BitbucketUser != "" && cmdFlags.BitbucketAppPass != "" {
 		logger.Info("Using basic authentication",
 			zap.String("username", cmdFlags.BitbucketUser))
@@ -91,7 +103,9 @@ func runCmdExport(cmdFlags *data.CmdFlags, logger *zap.Logger) error {
 	// Create Bitbucket client and exporter
 	client := utils.NewClient(
 		cmdFlags.BitbucketAPIURL,
-		cmdFlags.BitbucketToken,
+		cmdFlags.BitbucketAccessToken,
+		cmdFlags.BitbucketAPIToken,
+		cmdFlags.BitbucketEmail,
 		cmdFlags.BitbucketUser,
 		cmdFlags.BitbucketAppPass,
 		logger,

--- a/internal/data/bbdata.go
+++ b/internal/data/bbdata.go
@@ -1,16 +1,18 @@
 package data
 
 type CmdFlags struct {
-	BitbucketToken   string
-	BitbucketUser    string
-	BitbucketAppPass string
-	BitbucketAPIURL  string
-	Repository       string
-	Workspace        string
-	OutputDir        string
-	PRsFromDate      string // Format: YYYY-MM-DD
-	OpenPRsOnly      bool
-	Debug            bool
+	BitbucketAccessToken string
+	BitbucketUser        string // Will be deprecated with AppPass Sept 2025
+	BitbucketEmail       string // Will replace username after Sept 2025
+	BitbucketAppPass     string // Will be deprecated from BB Sept 2025
+	BitbucketAPIToken    string // Will replace AppPass after Sept 2025
+	BitbucketAPIURL      string
+	Repository           string
+	Workspace            string
+	OutputDir            string
+	PRsFromDate          string // Format: YYYY-MM-DD
+	OpenPRsOnly          bool
+	Debug                bool
 }
 
 type BitbucketRepository struct {

--- a/internal/data/ghddata_test.go
+++ b/internal/data/ghddata_test.go
@@ -155,7 +155,7 @@ func TestCmdFlagsDefaults(t *testing.T) {
 	assert.Empty(t, flags.Workspace)
 	assert.Empty(t, flags.Repository)
 	assert.Empty(t, flags.OutputDir)
-	assert.Empty(t, flags.BitbucketToken)
+	assert.Empty(t, flags.BitbucketAccessToken)
 	assert.Empty(t, flags.BitbucketUser)
 	assert.Empty(t, flags.BitbucketAppPass)
 	assert.Empty(t, flags.BitbucketAPIURL)

--- a/internal/utils/bitbucket_test.go
+++ b/internal/utils/bitbucket_test.go
@@ -28,11 +28,13 @@ func writeResponse(t *testing.T, w http.ResponseWriter, data []byte) {
 
 func TestNewClient(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	client := NewClient("https://example.com", "token", "user", "pass", logger)
+	client := NewClient("https://example.com", "token", "api-token", "email", "user", "pass", logger)
 
 	assert.NotNil(t, client)
 	assert.Equal(t, "https://example.com", client.baseURL)
-	assert.Equal(t, "token", client.token)
+	assert.Equal(t, "token", client.accessToken)
+	assert.Equal(t, "api-token", client.apiToken)
+	assert.Equal(t, "email", client.email)
 	assert.Equal(t, "user", client.username)
 	assert.Equal(t, "pass", client.appPass)
 	assert.NotNil(t, client.httpClient)
@@ -918,7 +920,7 @@ func TestGetFullCommitSHAWithAPICall(t *testing.T) {
 		baseURL:        testServer.URL,
 		httpClient:     testServer.Client(),
 		logger:         logger,
-		token:          "test-token",
+		accessToken:    "test-token",
 		commitSHACache: make(map[string]string),
 	}
 


### PR DESCRIPTION
**Authentication method updates:**

* The documentation in `README.md` now recommends Bitbucket API tokens as the primary authentication method, describes how to create them, and clearly marks basic authentication with app passwords as deprecated and scheduled for discontinuation after September 9, 2025.
* CLI flags and environment variables in `cmd/root.go`, `internal/data/bbdata.go`, and `README.md` are updated to support `--api-token`, `--access-token`, and `--email`, while deprecating the previous `--token` flag. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R130) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R149) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R166) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL48-R69) [[5]](diffhunk://#diff-02b37770a886b8cbeea5496e279a6bd903fdde0f61ea9ac1f221f257a8745034L4-R8)

**Internal logic and client refactoring:**

* The Bitbucket client in `internal/utils/bitbucket.go` is refactored to support API tokens (with email or x-bitbucket-api-token-auth), workspace access tokens, and legacy app password authentication, with corresponding changes to request headers and authentication flows. [[1]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL21-R48) [[2]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL50-R63) [[3]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL121-R146)
* The exporter logic in `internal/utils/exporter.go` now constructs repository clone URLs according to the selected authentication method, with improved error logging for authentication failures and a helper function to describe the authentication method used. [[1]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fL75-R111) [[2]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fR803-R816)

**Testing and validation:**

* Unit tests in `internal/utils/bitbucket_test.go` and `internal/utils/exporter_test.go` are updated to cover the new authentication flows and validate correct behavior for API tokens, workspace access tokens, and app passwords. [[1]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L31-R37) [[2]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L921-R923) [[3]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88R732-R782) [[4]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88R806-R812)

**Other updates:**

* Minor improvements to flag ordering, error messaging, and comments throughout the codebase ensure clarity and maintainability. [[1]](diffhunk://#diff-da1cfaf4818f09fd05dd362d208a299d8c4706b5f2f5f9403dcffe6203709a8cL158-R158) [[2]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fR8) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL84-R97) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL94-R108)

---

**References:**  
[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R72) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R130) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R149) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R166) [[5]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL48-R69) [[6]](diffhunk://#diff-02b37770a886b8cbeea5496e279a6bd903fdde0f61ea9ac1f221f257a8745034L4-R8) [[7]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL21-R48) [[8]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL50-R63) [[9]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL121-R146) [[10]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fL75-R111) [[11]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fR803-R816) [[12]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L31-R37) [[13]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52L921-R923) [[14]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88R732-R782) [[15]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88R806-R812) [[16]](diffhunk://#diff-da1cfaf4818f09fd05dd362d208a299d8c4706b5f2f5f9403dcffe6203709a8cL158-R158) [[17]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fR8) [[18]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL84-R97) [[19]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL94-R108)


Closes #32 