### PR TITLE
Updating to allow capitalized repo names

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,17 +29,6 @@ body:
         - Other
     validations:
       required: true
-  - type: dropdown
-    id: go-version
-    attributes:
-      label: Go Version
-      description: What version of Go are you using?
-      options:
-        - 1.19
-        - 1.20
-        - 1.21
-        - 1.22
-        - Other
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ using GitHub owned storage and GEI. Detailed documentation can be found in
 - [Archives larger than 40 GiB][storage-increase] are not supported by GitHub-owned storage
 - GitHub Enterprise Cloud with data residency is not supported
 
+### Repository Name Handling
+
+When exporting repositories with special characters in their names:
+
+- The tool will preserve capitalization in repository names (e.g., `RepositoryUIName`)
+- If a repository name contains special characters that aren't allowed in GitHub repository names
+  (e.g., `@group-test/ui`), the tool will use the Bitbucket slug (e.g., `group-test-ui`) for compatibility
+- Repository slugs are always used for directory names and internal references to ensure consistency
+
 ## Troubleshooting
 
 ### Common Issues

--- a/docs/GHImport.md
+++ b/docs/GHImport.md
@@ -4,13 +4,13 @@ This import process can utilize multiple storage options:
 
 1. Azure Storage Blobs
 2. AWS S3 Buckets
-3. [GitHub-owned storage (private preview)](https://github.blog/changelog/2024-11-21-migrate-repositories-with-github-enterprise-importer-using-github-owned-blob-storage-private-preview/)
+3. [GitHub-owned storage (public preview)][gh-storage]
 
 Each option provides a pathway for migrating Bitbucket Cloud repositories to
 GitHub Enterprise Cloud using the GitHub Enterprise Importer (GEI).
 
 > [!Note]
-> The GitHub-owned storage functionality is in private preview and subject to change.
+> The GitHub-owned storage functionality is in public preview and accessible to all.
 
 ## Limitations
 
@@ -70,8 +70,10 @@ gh gei migrate-repo \
 
 ### Using GitHub-owned storage
 
-If you have access to the
-[private preview of GitHub-owned storage][private-storage], use this command:
+This functionality is now in public review and accessible to all.
+
+To use the
+[public preview of GitHub-owned storage][private-storage], use this command:
 
 ```sh
 gh gei migrate-repo \
@@ -487,3 +489,4 @@ to get your operations up and running. Additional post-migration steps that shou
 [migration-state]: https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/enums#migrationstate
 [migration-logs]: https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/accessing-your-migration-logs-for-github-enterprise-importer
 [reclaim-mannequin]: https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/reclaiming-mannequins-for-github-enterprise-importer
+[gh-storage]: https://github.blog/changelog/2025-08-18-migrate-repositories-with-github-owned-blob-storage

--- a/internal/utils/exporter.go
+++ b/internal/utils/exporter.go
@@ -26,6 +26,8 @@ type Exporter struct {
 	prsFromDate string
 }
 
+var repoNameInvalidCharsRegex = regexp.MustCompile(`[^a-zA-Z0-9\-\._]|^\.|\.$/`)
+
 func NewExporter(client *Client, outputDir string, logger *zap.Logger, openPRsOnly bool, prsFromDate string) *Exporter {
 	return &Exporter{
 		client:      client,
@@ -463,11 +465,10 @@ func (e *Exporter) createOrganizationData(workspace string) []data.Organization 
 }
 
 func (e *Exporter) createRepositoriesData(repo *data.BitbucketRepository, workspace string) []data.Repository {
-
 	createdAt := formatDateToZ(repo.CreatedOn)
 	repoName := repo.Name
-	invalidCharsRegex := regexp.MustCompile(`[^a-zA-Z0-9\-\._]|^\.|\.$/`)
-	hasInvalidChars := invalidCharsRegex.MatchString(repo.Name)
+
+	hasInvalidChars := repoNameInvalidCharsRegex.MatchString(repo.Name)
 	namesDifferIgnoringCase := !strings.EqualFold(repo.Name, repo.Slug)
 
 	if hasInvalidChars || namesDifferIgnoringCase {

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -182,7 +182,8 @@ func (e *Exporter) updateRepositoryField(repoSlug string, field string, value in
 
 	repoUpdated := false
 	for i, repo := range repositories {
-		if repo.Name == repoSlug {
+		// Case-insensitive comparison for name, exact match for slug (always lowercase)
+		if strings.EqualFold(repo.Name, repoSlug) || repo.Slug == repoSlug {
 			switch field {
 			case "default_branch":
 				repositories[i].DefaultBranch = value.(string)

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -824,7 +824,8 @@ func TestUpdateRepositoryFieldCaseInsensitive(t *testing.T) {
 		}
 	}()
 
-	logger, _ := zap.NewDevelopment()
+	logger, err := zap.NewDevelopment()
+	assert.NoError(t, err)
 	exporter := NewExporter(&Client{}, tempDir, logger, false, "")
 
 	// Create a test case with different capitalization


### PR DESCRIPTION
**Repository Name Handling:**
- Added logic in `exporter.go` to detect special characters or capitalization differences in repository names, using the Bitbucket slug for compatibility and consistency when necessary. This ensures exported repositories are named appropriately for GitHub and internal references. [[1]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fR29-R30) [[2]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fL465-R486)
- Updated the repository field update logic to allow case-insensitive matching on repository names and exact matching on slugs, improving robustness when updating repository metadata.

**Documentation Updates:**
- Updated `GHImport.md` and `README.md` to clarify that GitHub-owned storage is now in public preview (not private preview), and added a section explaining how repository names and slugs are handled during export. [[1]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L7-R13) [[2]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0L73-R76) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R219-R227) [[4]](diffhunk://#diff-3e29fc7cd18197ecb951d4559205b4115f57d20b54b3bf4ef1c48eac60920bb0R492)

**Test Improvements:**
- Added a comprehensive test to `helpers_test.go` to verify case-insensitive updates to repository fields, correct handling of slugs, and logging when repositories are not found.

**Other:**
- Removed the "Go Version" dropdown from the bug report issue template to simplify issue submissions.
- Added missing imports for regular expressions and zap test observers to support new logic and testing. [[1]](diffhunk://#diff-c4e08b27e1f5fdcbbb35a14253d0b7e03b4bc2376afa46c6b52a9ae561d6cd7fR12) [[2]](diffhunk://#diff-18297b8f134ac29310e8b487eaa0bc0647fee4c8f5abdf53600efc6565eef5a0R4) [[3]](diffhunk://#diff-18297b8f134ac29310e8b487eaa0bc0647fee4c8f5abdf53600efc6565eef5a0R16)


Closes #41 