### PR TITLE
Ensuring `gh` cli auth works with `gh bbc-exporter migrate` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ indicating which references need to be renamed in Bitbucket before attempting th
    branch/tag name or a commit SHA. To resolve:
    - Rename the problematic branches/tags in Bitbucket to use non-ambiguous names
    - Re-run the export after renaming
+6. **GitHub CLI Authentication Issues**
+   If using `gh` CLI authentication and you receive
+   `GraphQL: <user> does not have the correct permissions to execute`, it is likely due to auth permissions
+   from the CLI. See [`gh auth login`](https://cli.github.com/manual/gh_auth_login) for details on `--scopes`.
 
 ## Development
 

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -108,7 +108,7 @@ func NewCmdMigrate() *cobra.Command {
 			logger.Debug("REST client created successfully")
 
 			logger.Debug("Starting migration process")
-			return runCmdMigrate(&exportFlags, &migrateFlags, utils.NewAPIGetter(gqlClient, restClient), logger)
+			return runCmdMigrate(&exportFlags, &migrateFlags, utils.NewAPIGetter(gqlClient, restClient, authToken), logger)
 		},
 	}
 

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -65,7 +65,7 @@ func NewCmdMigrate() *cobra.Command {
 			host := "github.com"
 
 			logger.Debug("Retrieving GitHub authentication token")
-			authToken, err = utils.GetGitHubAuthToken(&migrateFlags)
+			authToken, err = utils.GetGitHubAuthToken(&migrateFlags, logger)
 			if err != nil {
 				logger.Debug("Failed to get GitHub authentication token", zap.Error(err))
 				return fmt.Errorf("failed to get GitHub authentication token: %w", err)

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -36,7 +36,13 @@ func GetGitHubAuthToken(migrateFlags *data.CmdMigrateFlags) (string, error) {
 		return migrateFlags.GitHubPAT, nil
 	}
 
+	host := "github.com"
 	token, _ := auth.TokenForHost("github.com")
+	if token == "" {
+		return "", fmt.Errorf("no GitHub auth token found for host %s; "+
+			"use --github-target-pat / GITHUB_PAT or run `gh auth login -h %s`", host, host)
+	}
+
 	return token, nil
 }
 

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -27,23 +27,27 @@ var (
 	prNumberPattern           = regexp.MustCompile(`\b#(\d+)\b`)
 )
 
-func GetGitHubAuthToken(migrateFlags *data.CmdMigrateFlags) (string, error) {
-	if migrateFlags.GitHubPAT == "" {
-		migrateFlags.GitHubPAT = os.Getenv("GITHUB_PAT")
+func GetGitHubAuthToken(migrateFlags *data.CmdMigrateFlags, logger *zap.Logger) (string, error) {
+	if migrateFlags.GitHubPAT != "" {
+		logger.Debug("Using GitHub PAT from flag")
+		return migrateFlags.GitHubPAT, nil
 	}
 
-	if migrateFlags.GitHubPAT != "" {
-		return migrateFlags.GitHubPAT, nil
+	if envToken := os.Getenv("GITHUB_PAT"); envToken != "" {
+		logger.Debug("Using GitHub PAT from environment variable GITHUB_PAT")
+		migrateFlags.GitHubPAT = envToken
+		return envToken, nil
 	}
 
 	host := "github.com"
 	token, _ := auth.TokenForHost("github.com")
-	if token == "" {
-		return "", fmt.Errorf("no GitHub auth token found for host %s; "+
-			"use --github-target-pat / GITHUB_PAT or run `gh auth login -h %s`", host, host)
+	if token != "" {
+		logger.Debug("Using GitHub token from gh CLI keychain")
+		return token, nil
 	}
 
-	return token, nil
+	return "", fmt.Errorf("no GitHub auth token found for host %s; "+
+		"use --github-target-pat / GITHUB_PAT or run `gh auth login -h %s`", host, host)
 }
 
 func formatDateToZ(inputDate string) string {

--- a/internal/utils/import.go
+++ b/internal/utils/import.go
@@ -19,12 +19,14 @@ type Getter interface {
 type APIGetter struct {
 	gqlClient  api.GraphQLClient
 	restClient api.RESTClient
+	authToken  string
 }
 
-func NewAPIGetter(gqlClient *api.GraphQLClient, restClient *api.RESTClient) *APIGetter {
+func NewAPIGetter(gqlClient *api.GraphQLClient, restClient *api.RESTClient, authToken string) *APIGetter {
 	return &APIGetter{
 		gqlClient:  *gqlClient,
 		restClient: *restClient,
+		authToken:  authToken,
 	}
 }
 
@@ -100,15 +102,6 @@ func RunGitHubAPIMigration(exportFlags *data.CmdExportFlags, migrateFlags *data.
 		zap.String("source", fmt.Sprintf("%s/%s", exportFlags.Workspace, exportFlags.Repository)),
 		zap.String("target", fmt.Sprintf("%s/%s", migrateFlags.TargetOrg, targetRepo)))
 
-	logger.Debug("Step 4: Retrieving GitHub authentication token")
-	authToken, err := GetGitHubAuthToken(migrateFlags)
-	if err != nil {
-		logger.Debug("Failed to get GitHub authentication token", zap.Error(err))
-		return fmt.Errorf("failed to get GitHub authentication token: %w", err)
-	}
-	logger.Debug("GitHub authentication token retrieved",
-		zap.Int("tokenLength", len(authToken)))
-
 	visibility := migrateFlags.TargetRepoVisibility.String()
 	logger.Debug("Using repository visibility", zap.String("visibility", visibility))
 
@@ -122,7 +115,7 @@ func RunGitHubAPIMigration(exportFlags *data.CmdExportFlags, migrateFlags *data.
 		zap.String("visibility", visibility))
 
 	migrationID, err := g.startRepositoryMigration(migrationSourceID, orgInfo.Organization.ID, targetRepo, archiveURI,
-		sourceURL, visibility, authToken)
+		sourceURL, visibility)
 	if err != nil {
 		logger.Debug("Failed to start migration", zap.Error(err))
 		return fmt.Errorf("failed to start migration: %w", err)
@@ -175,7 +168,7 @@ func (g *APIGetter) createMigrationSource(name string, url string, ownerID strin
 	return migrationSourceID, nil
 }
 
-func (g *APIGetter) startRepositoryMigration(sourceID string, orgID string, targetRepo string, archiveURI string, sourceURL string, visibility string, githubPAT string) (string, error) {
+func (g *APIGetter) startRepositoryMigration(sourceID string, orgID string, targetRepo string, archiveURI string, sourceURL string, visibility string) (string, error) {
 	mutation := new(data.StartMigrationResponse)
 	variables := map[string]interface{}{
 		"input": data.StartRepositoryMigrationInput{
@@ -183,8 +176,8 @@ func (g *APIGetter) startRepositoryMigration(sourceID string, orgID string, targ
 			OwnerID:              graphql.String(orgID),
 			RepositoryName:       graphql.String(targetRepo),
 			ContinueOnError:      graphql.Boolean(true),
-			GitHubPAT:            graphql.String(githubPAT),
-			AccessToken:          graphql.String(githubPAT),
+			GitHubPAT:            graphql.String(g.authToken),
+			AccessToken:          graphql.String(g.authToken),
 			GitArchiveUrl:        graphql.String(archiveURI),
 			MetadataArchiveUrl:   graphql.String(archiveURI),
 			SourceRepositoryUrl:  graphql.String(sourceURL),

--- a/internal/utils/import_test.go
+++ b/internal/utils/import_test.go
@@ -285,7 +285,7 @@ func TestNewAPIGetter(t *testing.T) {
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
 
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	assert.NotNil(t, apiGetter)
 }
@@ -293,9 +293,20 @@ func TestNewAPIGetter(t *testing.T) {
 func TestGetOrganizationInfo(t *testing.T) {
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	assert.NotNil(t, apiGetter)
+}
+
+func TestAPIGetterCreation(t *testing.T) {
+	gqlClient := &api.GraphQLClient{}
+	restClient := &api.RESTClient{}
+
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
+
+	assert.NotNil(t, apiGetter)
+	assert.NotNil(t, apiGetter.gqlClient)
+	assert.NotNil(t, apiGetter.restClient)
 }
 
 func TestCreateMigrationSourceInputStruct(t *testing.T) {
@@ -621,17 +632,6 @@ func TestMigrationSourceCreationInput(t *testing.T) {
 	assert.Equal(t, url, string(input.URL))
 	assert.Equal(t, ownerID, string(input.OwnerID))
 	assert.Equal(t, "GITHUB_ARCHIVE", string(input.Type))
-}
-
-func TestAPIGetterCreation(t *testing.T) {
-	gqlClient := &api.GraphQLClient{}
-	restClient := &api.RESTClient{}
-
-	apiGetter := NewAPIGetter(gqlClient, restClient)
-
-	assert.NotNil(t, apiGetter)
-	assert.NotNil(t, apiGetter.gqlClient)
-	assert.NotNil(t, apiGetter.restClient)
 }
 
 func TestMigrationArchivePathValidation(t *testing.T) {

--- a/internal/utils/import_test.go
+++ b/internal/utils/import_test.go
@@ -548,7 +548,7 @@ func TestGetGitHubAuthTokenFromFlags(t *testing.T) {
 				GitHubPAT: tc.flagPAT,
 			}
 
-			token, err := GetGitHubAuthToken(migrateFlags)
+			token, err := GetGitHubAuthToken(migrateFlags, zap.NewNop())
 			if tc.expectedPAT != "" {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedPAT, token)

--- a/internal/utils/upload.go
+++ b/internal/utils/upload.go
@@ -98,7 +98,7 @@ func (g *APIGetter) uploadSingleFile(ctx context.Context, orgID int, file *os.Fi
 
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("User-Agent", "gh-bbc-exporter")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("GITHUB_PAT")))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", g.authToken))
 	req.ContentLength = fileSize
 
 	logger.Debug("Request headers set",
@@ -317,27 +317,11 @@ func (g *APIGetter) startMultipartUpload(ctx context.Context, orgID int, fileNam
 
 	logger.Debug("Request body prepared", zap.String("body", string(bodyBytes)))
 
-	// Create HTTP client for direct upload
-	httpClient := &http.Client{
-		Timeout: 60 * time.Minute,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", uploadURL, bytes.NewReader(bodyBytes))
-	if err != nil {
-		logger.Debug("Failed to create HTTP request", zap.Error(err))
-		return "", "", "", fmt.Errorf("failed to create HTTP request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "gh-bbc-exporter")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("GITHUB_PAT")))
-	req.Header.Set("GraphQL-Features", "octoshift_github_owned_storage")
-
-	logger.Debug("Sending multipart upload initiation request",
+	logger.Debug("Sending multipart upload initiation request via REST client",
 		zap.String("method", "POST"),
 		zap.String("url", uploadURL))
 
-	resp, err := httpClient.Do(req)
+	resp, err := g.restClient.Request("POST", uploadURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		logger.Debug("Failed to start upload", zap.Error(err))
 		return "", "", "", fmt.Errorf("failed to start upload: %w", err)
@@ -396,36 +380,18 @@ func (g *APIGetter) startMultipartUpload(ctx context.Context, orgID int, fileNam
 func (g *APIGetter) uploadPart(ctx context.Context, location string, data []byte, partNumber int, logger *zap.Logger) (string, error) {
 	uploadURL := uploadsHost + location
 
-	logger.Debug("Uploading part",
+	logger.Debug("Uploading part via REST client",
 		zap.Int("partNumber", partNumber),
 		zap.Int("dataSize", len(data)),
 		zap.String("url", uploadURL))
 
-	httpClient := &http.Client{
-		Timeout: 60 * time.Minute,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "PATCH", uploadURL, bytes.NewReader(data))
-	if err != nil {
-		logger.Debug("Failed to create PATCH request",
-			zap.Int("partNumber", partNumber),
-			zap.Error(err))
-		return "", fmt.Errorf("failed to create PATCH request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("User-Agent", "gh-bbc-exporter")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("GITHUB_PAT")))
-	req.Header.Set("GraphQL-Features", "octoshift_github_owned_storage")
-	req.ContentLength = int64(len(data))
-
 	logger.Debug("Sending part upload request",
 		zap.Int("partNumber", partNumber),
 		zap.String("method", "PATCH"),
-		zap.Int64("contentLength", req.ContentLength))
+		zap.Int("contentLength", len(data)))
 
 	startTime := time.Now()
-	resp, err := httpClient.Do(req)
+	resp, err := g.restClient.Request("PATCH", uploadURL, bytes.NewReader(data))
 	duration := time.Since(startTime)
 	if err != nil {
 		logger.Debug("Failed to upload part",
@@ -466,30 +432,15 @@ func (g *APIGetter) uploadPart(ctx context.Context, location string, data []byte
 func (g *APIGetter) completeMultipartUpload(ctx context.Context, lastLocation string, logger *zap.Logger) (string, error) {
 	finalizeURL := uploadsHost + lastLocation
 
-	logger.Debug("Completing multipart upload",
+	logger.Debug("Completing multipart upload via REST client",
 		zap.String("finalizeURL", finalizeURL))
-
-	httpClient := &http.Client{
-		Timeout: 60 * time.Minute,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "PUT", finalizeURL, nil)
-	if err != nil {
-		logger.Debug("Failed to create finalize request", zap.Error(err))
-		return "", fmt.Errorf("failed to create finalize request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("User-Agent", "gh-bbc-exporter")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("GITHUB_PAT")))
-	req.Header.Set("GraphQL-Features", "octoshift_github_owned_storage")
 
 	logger.Debug("Sending finalize request",
 		zap.String("method", "PUT"),
 		zap.String("url", finalizeURL))
 
 	startTime := time.Now()
-	resp, err := httpClient.Do(req)
+	resp, err := g.restClient.Request("PUT", finalizeURL, nil)
 	duration := time.Since(startTime)
 	if err != nil {
 		logger.Debug("Failed to finalize upload",

--- a/internal/utils/upload.go
+++ b/internal/utils/upload.go
@@ -321,7 +321,7 @@ func (g *APIGetter) startMultipartUpload(ctx context.Context, orgID int, fileNam
 		zap.String("method", "POST"),
 		zap.String("url", uploadURL))
 
-	resp, err := g.restClient.Request("POST", uploadURL, bytes.NewReader(bodyBytes))
+	resp, err := g.restClient.RequestWithContext(ctx, "POST", uploadURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		logger.Debug("Failed to start upload", zap.Error(err))
 		return "", "", "", fmt.Errorf("failed to start upload: %w", err)
@@ -391,7 +391,7 @@ func (g *APIGetter) uploadPart(ctx context.Context, location string, data []byte
 		zap.Int("contentLength", len(data)))
 
 	startTime := time.Now()
-	resp, err := g.restClient.Request("PATCH", uploadURL, bytes.NewReader(data))
+	resp, err := g.restClient.RequestWithContext(ctx, "PATCH", uploadURL, bytes.NewReader(data))
 	duration := time.Since(startTime)
 	if err != nil {
 		logger.Debug("Failed to upload part",
@@ -440,7 +440,7 @@ func (g *APIGetter) completeMultipartUpload(ctx context.Context, lastLocation st
 		zap.String("url", finalizeURL))
 
 	startTime := time.Now()
-	resp, err := g.restClient.Request("PUT", finalizeURL, nil)
+	resp, err := g.restClient.RequestWithContext(ctx, "PUT", finalizeURL, nil)
 	duration := time.Since(startTime)
 	if err != nil {
 		logger.Debug("Failed to finalize upload",

--- a/internal/utils/upload_test.go
+++ b/internal/utils/upload_test.go
@@ -40,14 +40,11 @@ func TestUploadArchiveToGitHub(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	oldUploadsBaseURL := uploadsBaseURL
 	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
@@ -64,7 +61,7 @@ func TestUploadArchiveFileNotFound(t *testing.T) {
 
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	_, err := apiGetter.UploadArchiveToGitHub(12345, "/nonexistent/path/archive.tar.gz", logger)
 
@@ -93,14 +90,11 @@ func TestUploadSingleFile(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	file, err := os.Open(archivePath)
 	assert.NoError(t, err)
@@ -139,6 +133,10 @@ func TestUploadMultipartFileIntegration(t *testing.T) {
 				w.WriteHeader(http.StatusAccepted)
 				return
 			}
+			// Single file upload
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"uri": "gei://archive/test-archive-id"}`))
+			return
 		case "PATCH":
 			partNumber++
 			_, _ = io.ReadAll(r.Body)
@@ -161,15 +159,16 @@ func TestUploadMultipartFileIntegration(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
-	gqlClient := &api.GraphQLClient{}
-	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	restClient, err := api.NewRESTClient(api.ClientOptions{
+		Host:      testServer.URL,
+		AuthToken: "test-token",
+	})
+	assert.NoError(t, err)
 
+	gqlClient := &api.GraphQLClient{}
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 	oldUploadsBaseURL := uploadsBaseURL
 	oldUploadsHost := uploadsHost
 	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
@@ -214,14 +213,16 @@ func TestStartMultipartUpload(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
-	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	restClient, err := api.NewRESTClient(api.ClientOptions{
+		Host:      testServer.URL,
+		AuthToken: "test-token",
+	})
+	assert.NoError(t, err)
+
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	oldUploadsBaseURL := uploadsBaseURL
 	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
@@ -249,16 +250,17 @@ func TestUploadPartIntegration(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
-	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	restClient, err := api.NewRESTClient(api.ClientOptions{
+		Host:      testServer.URL,
+		AuthToken: "test-token",
+	})
+	assert.NoError(t, err)
 
-	// Override the uploads host for testing
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
+
 	oldUploadsHost := uploadsHost
 	uploadsHost = testServer.URL
 	defer func() { uploadsHost = oldUploadsHost }()
@@ -287,16 +289,16 @@ func TestCompleteMultipartUploadIntegration(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
-	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	restClient, err := api.NewRESTClient(api.ClientOptions{
+		Host:      testServer.URL,
+		AuthToken: "test-token",
+	})
+	assert.NoError(t, err)
 
-	// Override the uploads host for testing
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 	oldUploadsHost := uploadsHost
 	uploadsHost = testServer.URL
 	defer func() { uploadsHost = oldUploadsHost }()
@@ -324,14 +326,11 @@ func TestUploadArchiveServerError(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	oldUploadsBaseURL := uploadsBaseURL
 	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
@@ -352,14 +351,26 @@ func TestUploadLargeFileForceMultipart(t *testing.T) {
 	err = os.WriteFile(archivePath, []byte("test"), 0644)
 	assert.NoError(t, err)
 
-	_ = os.Setenv("GITHUB_PAT", "invalid-token-for-test")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer testServer.Close()
 
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
-	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	// Fix: Initialize REST client properly
+	restClient, err := api.NewRESTClient(api.ClientOptions{
+		Host:      testServer.URL,
+		AuthToken: "test-token",
+	})
+	assert.NoError(t, err)
+
+	apiGetter := NewAPIGetter(gqlClient, restClient, "invalid-token-for-test")
+
+	oldUploadsBaseURL := uploadsBaseURL
+	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
+	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
 
 	oldThreshold := DefaultMultipartThreshold
 	DefaultMultipartThreshold = 1
@@ -394,14 +405,11 @@ func TestUploadEmptyFile(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	oldUploadsBaseURL := uploadsBaseURL
 	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
@@ -422,14 +430,6 @@ func TestUploadWithMissingToken(t *testing.T) {
 	err = os.WriteFile(archivePath, []byte("test content"), 0644)
 	assert.NoError(t, err)
 
-	originalToken := os.Getenv("GITHUB_PAT")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-	defer func() {
-		if originalToken != "" {
-			_ = os.Setenv("GITHUB_PAT", originalToken)
-		}
-	}()
-
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
 		if auth == "" || auth == "Bearer " || !strings.HasPrefix(auth, "Bearer ") || len(strings.TrimPrefix(auth, "Bearer ")) == 0 {
@@ -448,7 +448,7 @@ func TestUploadWithMissingToken(t *testing.T) {
 
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "")
 
 	oldUploadsBaseURL := uploadsBaseURL
 	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
@@ -482,14 +482,11 @@ func TestUploadWithRetry(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	_ = os.Setenv("GITHUB_PAT", "test-token")
-	defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
-
 	logger, _ := zap.NewDevelopment()
 
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
-	apiGetter := NewAPIGetter(gqlClient, restClient)
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	oldUploadsBaseURL := uploadsBaseURL
 	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"


### PR DESCRIPTION
**Authentication and API Client Refactor:**

- The `APIGetter` struct now requires the GitHub auth token as a parameter, and all API calls use this token directly instead of reading from environment variables. This change is reflected in the constructor `NewAPIGetter` and all usages throughout the codebase, including in tests. [[1]](diffhunk://#diff-fd1af678f77fd3c21af38feef2b55476d24bf84132e7bc01565a9d27964ddb2fR22-R29) [[2]](diffhunk://#diff-8f2ac04ae3953157635d47a2cd60fed8c9af35ab53bb1a95e60fae61e212cfd4L101-R101) [[3]](diffhunk://#diff-8f2ac04ae3953157635d47a2cd60fed8c9af35ab53bb1a95e60fae61e212cfd4L320-R324) [[4]](diffhunk://#diff-8f2ac04ae3953157635d47a2cd60fed8c9af35ab53bb1a95e60fae61e212cfd4L399-R394) [[5]](diffhunk://#diff-8f2ac04ae3953157635d47a2cd60fed8c9af35ab53bb1a95e60fae61e212cfd4L469-R443) [[6]](diffhunk://#diff-ac876b4f4f56d82752e72b4a9b6e8c17e8d5546b9c7ebd573062337baefd1fd6L111-R111) [[7]](diffhunk://#diff-fd1af678f77fd3c21af38feef2b55476d24bf84132e7bc01565a9d27964ddb2fL103-L111) [[8]](diffhunk://#diff-fd1af678f77fd3c21af38feef2b55476d24bf84132e7bc01565a9d27964ddb2fL125-R118) [[9]](diffhunk://#diff-fd1af678f77fd3c21af38feef2b55476d24bf84132e7bc01565a9d27964ddb2fL178-R180) [[10]](diffhunk://#diff-74861c1f7b2e30c2aa3bea4d75d8ab65401d108b1fd26f712e9b614b922297f9L288-R311) [[11]](diffhunk://#diff-74861c1f7b2e30c2aa3bea4d75d8ab65401d108b1fd26f712e9b614b922297f9L626-L636) [[12]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L43-R47) [[13]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L67-R64) [[14]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L96-R97) [[15]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524R136-R139) [[16]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L164-R171) [[17]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L217-R225) [[18]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L252-L261) [[19]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L290-R301) [[20]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L327-R333) [[21]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L355-R373) [[22]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L397-R412)

- The upload and migration logic now passes the auth token explicitly, eliminating the use of `os.Getenv("GITHUB_PAT")` and making the code more robust and testable. [[1]](diffhunk://#diff-8f2ac04ae3953157635d47a2cd60fed8c9af35ab53bb1a95e60fae61e212cfd4L101-R101) [[2]](diffhunk://#diff-8f2ac04ae3953157635d47a2cd60fed8c9af35ab53bb1a95e60fae61e212cfd4L320-R324) [[3]](diffhunk://#diff-8f2ac04ae3953157635d47a2cd60fed8c9af35ab53bb1a95e60fae61e212cfd4L399-R394) [[4]](diffhunk://#diff-8f2ac04ae3953157635d47a2cd60fed8c9af35ab53bb1a95e60fae61e212cfd4L469-R443)

**Testing Improvements:**

- All tests have been updated to use the new `APIGetter` constructor with an explicit token, and no longer set or unset environment variables for authentication. Some tests now initialize the REST client with a test server and token. [[1]](diffhunk://#diff-74861c1f7b2e30c2aa3bea4d75d8ab65401d108b1fd26f712e9b614b922297f9L288-R311) [[2]](diffhunk://#diff-74861c1f7b2e30c2aa3bea4d75d8ab65401d108b1fd26f712e9b614b922297f9L626-L636) [[3]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L43-R47) [[4]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L67-R64) [[5]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L96-R97) [[6]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524R136-R139) [[7]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L164-R171) [[8]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L217-R225) [[9]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L252-L261) [[10]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L290-R301) [[11]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L327-R333) [[12]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L355-R373) [[13]](diffhunk://#diff-3f60aff01ed8ebbe171702721393e1604067155bcae083002a22a74865f33524L397-R412)

**Error Handling and User Guidance:**

- Improved error messages in `GetGitHubAuthToken` to guide users on missing authentication and how to resolve it.

**Documentation:**

- Added troubleshooting steps for GitHub CLI authentication issues, including a link to the `gh auth login` documentation.



Closes bug #62