### PR TITLE
Adding GHE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ repositories into a format compatible with GitHub Enterprise migrations.
 ## Overview
 
 This extension helps you migrate repositories from Bitbucket Cloud to GitHub Enterprise Cloud,
-GitHub Enterprise Cloud Managed Users, and GiThub Enterprise Cloud with data residency
+GitHub Enterprise Cloud Managed Users, and GitHub Enterprise Cloud with data residency
 by creating an export archive that matches the format expected by GitHub Enterprise Importer (GEI).
 
 The exporter creates a complete migration archive containing:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ repositories into a format compatible with GitHub Enterprise migrations.
 
 ## Overview
 
-This extension helps you migrate repositories from Bitbucket Cloud to GitHub Enterprise Cloud
+This extension helps you migrate repositories from Bitbucket Cloud to GitHub Enterprise Cloud,
+GitHub Enterprise Cloud Managed Users, and GiThub Enterprise Cloud with data residency
 by creating an export archive that matches the format expected by GitHub Enterprise Importer (GEI).
 
 The exporter creates a complete migration archive containing:
@@ -48,6 +49,16 @@ Bitbucket Cloud provides two authentication methods for their API:
 - API Tokens (recommended)
 - Workspace Access Tokens (premium membership)
 - Basic Authentication with App Passwords (deprecated, will be discontinued after September 9, 2025)
+
+> [!Important]
+> The extension uses the following authentication priority order:
+>
+> 1. Workspace Access Token (`--access-token` / `BITBUCKET_ACCESS_TOKEN`)
+> 2. API Token with Email (`--api-token` + `--email` / `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL`)
+> 3. API Token with header auth (`--api-token` / `BITBUCKET_API_TOKEN`)
+> 4. Username and App Password (`--user` + `--app-password` / `BITBUCKET_USERNAME` + `BITBUCKET_APP_PASSWORD`)
+>
+> If multiple methods are provided, a warning is displayed and the highest priority method is used.
 
 #### API Tokens
 
@@ -196,8 +207,7 @@ Flags:
   -a, --bbc-api-url string                                 Bitbucket API to use (default "https://api.bitbucket.org/2.0")
   -t, --access-token string                                Bitbucket workspace access token for authentication (env:
                                                            BITBUCKET_ACCESS_TOKEN)
-      --api-token string                                   Bitbucket API token for authentication (env:
-                                                           BITBUCKET_API_TOKEN)
+      --api-token string                                   Bitbucket API token for authentication (env: BITBUCKET_API_TOKEN)
   -e, --email string                                       Atlassian account email for API token authentication (env:
                                                            BITBUCKET_EMAIL)
   -u, --user string                                        Bitbucket username for basic authentication (env:
@@ -210,16 +220,18 @@ Flags:
   -o, --output string                                      Output directory for exported data (default:
                                                            ./bitbucket-export-TIMESTAMP)
       --open-prs-only                                      Export only open pull requests
-      --prs-from-date string                               Export pull requests created on or after this date
-                                                           (format: YYYY-MM-DD)
-      --skip-commit-lookup                                 Skip Bitbucket API lookups to retrieve commit SHAs (use
-                                                           local lookup only)
+      --prs-from-date string                               Export pull requests created on or after this date (format:
+                                                           YYYY-MM-DD)
+      --skip-commit-lookup                                 Skip Bitbucket API lookups to retrieve commit SHAs (use local
+                                                           lookup only)
       --target-org string                                  Target GitHub organization (required)
       --target-repo string                                 Target repository name (defaults to source repo name)
       --github-target-pat string                           GitHub Personal Access Token (env: GITHUB_PAT)
-      --target-repo-visibility <internal|private|public>   The visibility of the target repo. Defaults to private.
-                                                           Valid values are public, private, or internal. (default
-                                                           private)
+      --target-api-url string                              The URL of the target API, if not migrating to github.com.
+                                                           Defaults to https://api.github.com (default
+                                                           "https://api.github.com")
+      --target-repo-visibility <internal|private|public>   The visibility of the target repo. Defaults to private. Valid
+                                                           values are public, private, or internal. (default private)
   -d, --debug                                              Enable debug logging
 
 Global Flags:
@@ -251,6 +263,23 @@ gh bbc-exporter migrate -w bitbucket-workspace -r source-repo \
    --target-org github-org --github-target-pat ghp_xxxxx \
    -t your-bitbucket-token
 ```
+
+#### Migrating to GitHub Enterprise Cloud with Data Residency
+
+For migrations to a GHE.com instance, use the `--target-api-url` flag:
+
+```sh
+gh bbc-exporter migrate -w bitbucket-workspace -r source-repo \
+   --target-org github-org \
+   --target-api-url https://api.your-slug.ghe.com \
+   --github-target-pat ghp_xxxxx \
+   -t your-bitbucket-token
+```
+
+> [!Note]
+> GitHub Enterprise Cloud with data residency (GHE.com) requires the `--target-api-url` flag
+> pointing to your instance's API endpoint. The uploads URL is automatically derived from the
+> API URL. GitHub Enterprise Server (GHES) is not supported.
 
 ### Advanced Options
 
@@ -374,7 +403,7 @@ orchestrate the migration.
 - Repository and Pull request labels have not been implemented
 - User information is limited to what's available from Bitbucket API
 - [Archives larger than 40 GiB][storage-increase] are not supported by GitHub-owned storage
-- GitHub Enterprise Cloud with data residency is not supported
+- GitHub Enterprise Server (GHES) is not supported as a migration target
 
 ### Repository Name Handling
 

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -36,6 +36,15 @@ func cleanupExportDirs(t *testing.T) {
 	}
 }
 
+func TestExportDefaultBitbucketAPIURL(t *testing.T) {
+	cmd := NewCmdExport()
+
+	flag := cmd.PersistentFlags().Lookup("bbc-api-url")
+	assert.NotNil(t, flag)
+	assert.Equal(t, "https://api.bitbucket.org/2.0", flag.DefValue,
+		"Default Bitbucket API URL should be the standard endpoint")
+}
+
 func TestValidateExportFlagsMixedAuth(t *testing.T) {
 	CmdExportFlags := &data.CmdExportFlags{
 		BitbucketAccessToken: "testtoken",
@@ -123,6 +132,47 @@ func TestPRFilteringFlagsIntegration(t *testing.T) {
 	assert.Equal(t, "2023-01-01", CmdExportFlags.PRsFromDate, "Expected PRsFromDate to be set")
 }
 
+func TestExportCommandLongDescription(t *testing.T) {
+	cmd := NewCmdExport()
+
+	assert.NotEmpty(t, cmd.Long, "Long description should not be empty")
+	assert.Contains(t, cmd.Long, "Bitbucket", "Long description should mention Bitbucket")
+}
+
+func TestExportCommandExample(t *testing.T) {
+	cmd := NewCmdExport()
+
+	if cmd.Example != "" {
+		assert.Contains(t, cmd.Example, "export", "Example should include export command")
+	}
+}
+
+func TestExportFlagShorthands(t *testing.T) {
+	cmd := NewCmdExport()
+
+	shorthandFlags := map[string]string{
+		"a": "bbc-api-url",
+		"t": "access-token",
+		"e": "email",
+		"u": "user",
+		"p": "app-password",
+		"w": "workspace",
+		"r": "repo",
+		"o": "output",
+		"d": "debug",
+	}
+
+	for shorthand, fullName := range shorthandFlags {
+		t.Run(fullName, func(t *testing.T) {
+			flag := cmd.PersistentFlags().Lookup(fullName)
+			assert.NotNil(t, flag, "Flag %s should exist", fullName)
+			if flag != nil {
+				assert.Equal(t, shorthand, flag.Shorthand, "Flag %s should have shorthand %s", fullName, shorthand)
+			}
+		})
+	}
+}
+
 func TestExecuteWithInvalidFlags(t *testing.T) {
 	rootCmd := NewCmdExport()
 	buf := new(bytes.Buffer)
@@ -135,6 +185,23 @@ func TestExecuteWithInvalidFlags(t *testing.T) {
 
 	output := buf.String()
 	assert.Contains(t, output, "bitbucket workspace must be specified")
+}
+
+func TestExportCommandDisabledFlagSorting(t *testing.T) {
+	cmd := NewCmdExport()
+
+	assert.False(t, cmd.Flags().SortFlags, "Regular flags should not be sorted")
+	assert.False(t, cmd.PersistentFlags().SortFlags, "Persistent flags should not be sorted")
+}
+
+func TestExportCommandHasPreRunE(t *testing.T) {
+	cmd := NewCmdExport()
+	assert.NotNil(t, cmd.PreRunE, "Export command should have PreRunE set")
+}
+
+func TestExportCommandHasRunE(t *testing.T) {
+	cmd := NewCmdExport()
+	assert.NotNil(t, cmd.RunE, "Export command should have RunE set")
 }
 
 func TestExecuteWithValidFlags(t *testing.T) {

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -67,7 +67,7 @@ func NewCmdMigrate() *cobra.Command {
 				zap.String("targetRepo", migrateFlags.TargetRepo),
 				zap.String("targetAPIURL", migrateFlags.TargetAPIURL))
 
-			host, _, err := utils.GetAPIURLhost(migrateFlags.TargetAPIURL)
+			host, _, err := utils.GetAPIURLHost(migrateFlags.TargetAPIURL)
 			if err != nil {
 				return fmt.Errorf("invalid target API URL: %w", err)
 			}
@@ -252,7 +252,7 @@ func runCmdMigrate(exportFlags *data.CmdExportFlags, migrateFlags *data.CmdMigra
 		return fmt.Errorf("unsupported target for migration uploads: %w", err)
 	}
 
-	utils.SetUploadsBaseURL(newUploadsBaseURL, newUploadsHost)
+	g.SetUploadsBaseURL(newUploadsBaseURL, newUploadsHost)
 	logger.Debug("Uploads base URL configured",
 		zap.String("uploadsBaseURL", newUploadsBaseURL),
 		zap.String("uploadsHost", newUploadsHost))

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -31,6 +31,10 @@ func NewCmdMigrate() *cobra.Command {
 			if migrateFlags.TargetOrg == "" {
 				return fmt.Errorf("target GitHub organization must be specified")
 			}
+			_, _, err := utils.GetUploadsBaseURL(migrateFlags.TargetAPIURL)
+			if err != nil {
+				return fmt.Errorf("unsupported target API URL: %w", err)
+			}
 
 			if exportFlags.PRsFromDate != "" {
 				_, err := time.Parse("2006-01-02", exportFlags.PRsFromDate)

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -60,9 +60,13 @@ func NewCmdMigrate() *cobra.Command {
 				zap.String("workspace", exportFlags.Workspace),
 				zap.String("repository", exportFlags.Repository),
 				zap.String("targetOrg", migrateFlags.TargetOrg),
-				zap.String("targetRepo", migrateFlags.TargetRepo))
+				zap.String("targetRepo", migrateFlags.TargetRepo),
+				zap.String("targetAPIURL", migrateFlags.TargetAPIURL))
 
-			host := "github.com"
+			host, _, err := utils.GetAPIURLhost(migrateFlags.TargetAPIURL)
+			if err != nil {
+				return fmt.Errorf("invalid target API URL: %w", err)
+			}
 
 			logger.Debug("Retrieving GitHub authentication token")
 			authToken, err = utils.GetGitHubAuthToken(&migrateFlags, logger)
@@ -75,6 +79,7 @@ func NewCmdMigrate() *cobra.Command {
 
 			logger.Debug("Creating GraphQL client",
 				zap.String("host", host))
+
 			gqlClient, err = api.NewGraphQLClient(api.ClientOptions{
 				Headers: map[string]string{
 					"Accept": "application/vnd.github.hawkgirl-preview+json",
@@ -145,6 +150,8 @@ func NewCmdMigrate() *cobra.Command {
 		"Target repository name (defaults to source repo name)")
 	migrateCmd.PersistentFlags().StringVar(&migrateFlags.GitHubPAT, "github-target-pat", "",
 		"GitHub Personal Access Token (env: GITHUB_PAT)")
+	migrateCmd.PersistentFlags().StringVar(&migrateFlags.TargetAPIURL, "target-api-url", "https://api.github.com",
+		"The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com")
 	migrateCmd.PersistentFlags().Var(&migrateFlags.TargetRepoVisibility, "target-repo-visibility",
 		"The visibility of the target repo. Defaults to private. Valid values are public, private, or internal.")
 	migrateCmd.PersistentFlags().BoolVarP(&exportFlags.Debug, "debug", "d", false, "Enable debug logging")
@@ -235,6 +242,16 @@ func runCmdMigrate(exportFlags *data.CmdExportFlags, migrateFlags *data.CmdMigra
 
 	logger.Info("Step 2: Importing to GitHub Enterprise Cloud",
 		zap.String("archive", archivePath))
+
+	newUploadsBaseURL, newUploadsHost, err := utils.GetUploadsBaseURL(migrateFlags.TargetAPIURL)
+	if err != nil {
+		return fmt.Errorf("unsupported target for migration uploads: %w", err)
+	}
+
+	utils.SetUploadsBaseURL(newUploadsBaseURL, newUploadsHost)
+	logger.Debug("Uploads base URL configured",
+		zap.String("uploadsBaseURL", newUploadsBaseURL),
+		zap.String("uploadsHost", newUploadsHost))
 
 	logger.Debug("Starting GitHub API migration",
 		zap.String("archivePath", archivePath),

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1209,4 +1210,100 @@ func TestCmdMigrateFlagsEmbeddedExportFlags(t *testing.T) {
 	assert.Equal(t, "target-org", migrateFlags.TargetOrg)
 	assert.Equal(t, "target-repo", migrateFlags.TargetRepo)
 	assert.Equal(t, "private", migrateFlags.TargetRepoVisibility.String())
+}
+
+func TestMigrateTargetAPIURLFlag(t *testing.T) {
+	cmd := NewCmdMigrate()
+
+	flag := cmd.PersistentFlags().Lookup("target-api-url")
+	assert.NotNil(t, flag, "target-api-url flag should exist")
+	assert.Equal(t, "https://api.github.com", flag.DefValue,
+		"Default target API URL should be https://api.github.com")
+}
+
+func TestMigrateTargetAPIURLGHECom(t *testing.T) {
+	cmd := NewCmdMigrate()
+
+	testCases := []struct {
+		name        string
+		apiURL      string
+		expectedURL string
+	}{
+		{
+			name:        "Default GitHub.com API URL",
+			apiURL:      "",
+			expectedURL: "https://api.github.com",
+		},
+		{
+			name:        "GHE.com API URL",
+			apiURL:      "https://api.octocorp.ghe.com",
+			expectedURL: "https://api.octocorp.ghe.com",
+		},
+		{
+			name:        "GHES API URL",
+			apiURL:      "https://github.example.com/api/v3",
+			expectedURL: "https://github.example.com/api/v3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{
+				"--workspace", "test-ws",
+				"--repo", "test-repo",
+				"--target-org", "test-org",
+				"--github-target-pat", "ghp_test_token",
+				"--access-token", "test-bb-token",
+			}
+			if tc.apiURL != "" {
+				args = append(args, "--target-api-url", tc.apiURL)
+			}
+
+			err := cmd.ParseFlags(args)
+			assert.NoError(t, err)
+
+			val, err := cmd.PersistentFlags().GetString("target-api-url")
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedURL, val)
+		})
+	}
+}
+
+func TestMigrateCommandFlagsIncludesTargetAPIURL(t *testing.T) {
+	cmd := NewCmdMigrate()
+
+	expectedFlags := []string{
+		"target-api-url",
+		"target-org",
+		"target-repo",
+		"github-target-pat",
+		"target-repo-visibility",
+	}
+
+	for _, flagName := range expectedFlags {
+		flag := cmd.PersistentFlags().Lookup(flagName)
+		assert.NotNil(t, flag, "Flag %s should exist", flagName)
+	}
+}
+
+func TestMigrateFlagsWithTargetAPIURL(t *testing.T) {
+	flags := data.CmdMigrateFlags{
+		TargetOrg:            "github-org",
+		TargetRepo:           "github-repo",
+		TargetAPIURL:         "https://api.octocorp.ghe.com",
+		TargetRepoVisibility: data.RepoVisibility("private"),
+	}
+
+	assert.Equal(t, "https://api.octocorp.ghe.com", flags.TargetAPIURL)
+
+	jsonData, err := json.Marshal(flags)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, jsonData)
+
+	var unmarshaledFlags data.CmdMigrateFlags
+	err = json.Unmarshal(jsonData, &unmarshaledFlags)
+	assert.NoError(t, err)
+
+	assert.Equal(t, flags.TargetAPIURL, unmarshaledFlags.TargetAPIURL)
+	assert.Equal(t, flags.TargetOrg, unmarshaledFlags.TargetOrg)
 }

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -1370,6 +1370,7 @@ func TestMigratePreRunValidatesTargetAPIURL(t *testing.T) {
 }
 
 func TestMigrateGHESFailsFastBeforeExport(t *testing.T) {
+	cleanupExportDirs(t)
 	defer cleanupExportDirs(t)
 
 	cmd := NewCmdMigrate()

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -1307,3 +1307,85 @@ func TestMigrateFlagsWithTargetAPIURL(t *testing.T) {
 	assert.Equal(t, flags.TargetAPIURL, unmarshaledFlags.TargetAPIURL)
 	assert.Equal(t, flags.TargetOrg, unmarshaledFlags.TargetOrg)
 }
+
+func TestMigratePreRunValidatesTargetAPIURL(t *testing.T) {
+	defer cleanupExportDirs(t)
+
+	testCases := []struct {
+		name        string
+		apiURL      string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "GHES URL fails fast in PreRunE",
+			apiURL:      "https://github.example.com/api/v3",
+			expectError: true,
+			errorMsg:    "unsupported target API URL",
+		},
+		{
+			name:        "Non-GHE custom URL fails fast in PreRunE",
+			apiURL:      "https://custom.enterprise.com/api",
+			expectError: true,
+			errorMsg:    "unsupported target API URL",
+		},
+		{
+			name:        "Default github.com URL passes PreRunE",
+			apiURL:      "https://api.github.com",
+			expectError: false,
+		},
+		{
+			name:        "GHE.com URL passes PreRunE",
+			apiURL:      "https://api.octocorp.ghe.com",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewCmdMigrate()
+
+			args := []string{
+				"--workspace", "test-ws",
+				"--repo", "test-repo",
+				"--target-org", "test-org",
+				"--access-token", "test-token",
+				"--target-api-url", tc.apiURL,
+			}
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorMsg)
+			} else {
+				if err != nil {
+					assert.NotContains(t, err.Error(), "unsupported target API URL",
+						"PreRunE should not reject valid target API URL: %s", tc.apiURL)
+				}
+			}
+		})
+	}
+}
+
+func TestMigrateGHESFailsFastBeforeExport(t *testing.T) {
+	defer cleanupExportDirs(t)
+
+	cmd := NewCmdMigrate()
+	cmd.SetArgs([]string{
+		"--workspace", "test-ws",
+		"--repo", "test-repo",
+		"--target-org", "test-org",
+		"--access-token", "test-token",
+		"--target-api-url", "https://github.example.com/api/v3",
+	})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported target API URL")
+
+	// Verify no export directory was created (export never started)
+	matches, _ := filepath.Glob("./bitbucket-export-*")
+	assert.Empty(t, matches, "No export directory should be created when target API URL is invalid")
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -173,12 +173,12 @@ func TestNewCmdRootSubcommandNames(t *testing.T) {
 	cmd := NewCmdRoot()
 
 	subcommandNames := make([]string, 0)
-	for _, subCmd := range cmd.Commands() {
-		subcommandNames = append(subcommandNames, subCmd.Name())
+	for _, sub := range cmd.Commands() {
+		subcommandNames = append(subcommandNames, sub.Name())
 	}
 
-	assert.Contains(t, subcommandNames, "export")
-	assert.Contains(t, subcommandNames, "migrate")
+	assert.Contains(t, subcommandNames, "export", "Root should have export subcommand")
+	assert.Contains(t, subcommandNames, "migrate", "Root should have migrate subcommand")
 }
 
 func TestNewCmdRootNoRunFunction(t *testing.T) {

--- a/docs/Import-with-gei.md
+++ b/docs/Import-with-gei.md
@@ -5,6 +5,11 @@ Cloud using GitHub Enterprise Importer (GEI).
 
 ## Migration Methods
 
+> [!Note]
+> All methods below assume you have already exported your Bitbucket repository using the
+> `gh bbc-exporter export` command. If you prefer a single-step process, use the
+> `gh bbc-exporter migrate` command instead, which handles both export and import.
+
 There are three primary methods to perform the migration:
 
 1. **[Method 1: Automated with GitHub Actions (Recommended)](#method-1-automated-with-github-actions)**
@@ -236,6 +241,30 @@ After a successful migration:
 2. **[Reclaim mannequins][reclaim-mannequin]** to map migrated users to their GitHub accounts.
 3. **Configure workflows** and CI/CD pipelines.
 4. **Verify repository contents** and settings.
+5. **Verify pull request metadata** including reviews, comments, and review threads.
+
+---
+
+## Migrating to GHE.com (GitHub Enterprise Cloud with Data Residency)
+
+When migrating to a GHE.com instance, the API endpoints differ from standard GitHub.com:
+
+- **GraphQL API**: `https://api.<subdomain>.ghe.com/graphql`
+- **Uploads API**: `https://uploads.<subdomain>.ghe.com`
+
+The `gh bbc-exporter migrate` command automatically derives the correct upload URL when
+you provide the `--target-api-url` flag:
+
+```sh
+gh bbc-exporter migrate -w bitbucket-workspace -r source-repo \
+   --target-org github-org \
+   --target-api-url https://api.subdomain.ghe.com \
+   --github-target-pat ghp_xxxxx \
+   -t your-bitbucket-token
+```
+
+For manual API migration (Method 3), replace the GraphQL and upload endpoints with your
+GHE.com instance URLs in each step.
 
 ---
 

--- a/internal/data/import.go
+++ b/internal/data/import.go
@@ -12,6 +12,7 @@ type CmdMigrateFlags struct {
 	TargetOrg            string
 	TargetRepo           string
 	TargetRepoVisibility RepoVisibility
+	TargetAPIURL         string
 	GitHubPAT            string
 }
 

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -33,6 +33,29 @@ func TestNewLogger(t *testing.T) {
 	}()
 }
 
+func TestLogWarnAndErrorOutputs(t *testing.T) {
+	var buf bytes.Buffer
+
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	encoder := zapcore.NewConsoleEncoder(encoderConfig)
+	core := zapcore.NewCore(encoder, zapcore.AddSync(&buf), zap.DebugLevel)
+
+	testLogger := zap.New(core)
+
+	// Test warn level
+	testLogger.Warn("warn message", zap.String("detail", "something"))
+	assert.Contains(t, buf.String(), "warn message")
+	assert.Contains(t, buf.String(), "detail")
+
+	buf.Reset()
+
+	// Test error level
+	testLogger.Error("error message", zap.String("reason", "failure"))
+	assert.Contains(t, buf.String(), "error message")
+	assert.Contains(t, buf.String(), "reason")
+	assert.Contains(t, buf.String(), "failure")
+}
+
 func TestLogOutputs(t *testing.T) {
 	// Create a buffer to capture log output
 	var buf bytes.Buffer

--- a/internal/utils/exporter_test.go
+++ b/internal/utils/exporter_test.go
@@ -377,6 +377,40 @@ func TestCreateReviewThreads(t *testing.T) {
 	assert.Equal(t, "2023-01-01T14:00:00Z", threads[1]["created_at"])
 }
 
+func TestCreateReviewThreadsEmpty(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	exporter := NewExporter(&Client{}, "output", logger, false, "")
+
+	threads := exporter.createReviewThreads([]data.PullRequestReviewComment{})
+	assert.Empty(t, threads, "Empty comments should produce no threads")
+
+	threads = exporter.createReviewThreads(nil)
+	assert.Empty(t, threads, "Nil comments should produce no threads")
+}
+
+func TestCreateReviewsEmpty(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	exporter := NewExporter(&Client{}, "output", logger, false, "")
+
+	reviews := exporter.createReviews([]data.PullRequestReviewComment{})
+	assert.Empty(t, reviews, "Empty comments should produce no reviews")
+
+	reviews = exporter.createReviews(nil)
+	assert.Empty(t, reviews, "Nil comments should produce no reviews")
+}
+
+func TestValidateExportDataMissingFiles(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "validate-missing-")
+	assert.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	logger, _ := zap.NewDevelopment()
+	exporter := NewExporter(&Client{}, tempDir, logger, false, "")
+	assert.NotPanics(t, func() {
+		_ = exporter.validateExportData()
+	})
+}
+
 func TestCloneRepositoryErrors(t *testing.T) {
 	// Create a temporary directory for testing
 	tempDir, err := os.MkdirTemp("", "clone-test-")

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -40,7 +40,7 @@ func GetGitHubAuthToken(migrateFlags *data.CmdMigrateFlags, logger *zap.Logger) 
 		return envToken, nil
 	}
 
-	_, host, err := GetAPIURLhost(migrateFlags.TargetAPIURL)
+	_, host, err := GetAPIURLHost(migrateFlags.TargetAPIURL)
 	if err != nil || host == "" {
 		host = "github.com"
 	}
@@ -56,8 +56,8 @@ func GetGitHubAuthToken(migrateFlags *data.CmdMigrateFlags, logger *zap.Logger) 
 		"use --github-target-pat / GITHUB_PAT or run `gh auth login -h %s`", host, host)
 }
 
-func GetAPIURLhost(apiURL string) (string, string, error) {
-	if apiURL == "" || apiURL == "https://api.github.com" {
+func GetAPIURLHost(apiURL string) (string, string, error) {
+	if apiURL == "" {
 		return "api.github.com", "github.com", nil
 	}
 
@@ -69,6 +69,11 @@ func GetAPIURLhost(apiURL string) (string, string, error) {
 	host := parsed.Hostname()
 	if host == "" {
 		return "", "", fmt.Errorf("could not determine host from target API URL %q", apiURL)
+	}
+
+	// Treat any URL with api.github.com as the default GitHub.com endpoint
+	if host == "api.github.com" {
+		return "api.github.com", "github.com", nil
 	}
 
 	// For GHE.com URLs: https://api.<subdomain>.ghe.com

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,15 +40,45 @@ func GetGitHubAuthToken(migrateFlags *data.CmdMigrateFlags, logger *zap.Logger) 
 		return envToken, nil
 	}
 
-	host := "github.com"
-	token, _ := auth.TokenForHost("github.com")
+	_, host, err := GetAPIURLhost(migrateFlags.TargetAPIURL)
+	if err != nil || host == "" {
+		host = "github.com"
+	}
+
+	token, _ := auth.TokenForHost(host)
 	if token != "" {
-		logger.Debug("Using GitHub token from gh CLI keychain")
+		logger.Debug("Using GitHub token from gh CLI keychain",
+			zap.String("host", host))
 		return token, nil
 	}
 
 	return "", fmt.Errorf("no GitHub auth token found for host %s; "+
 		"use --github-target-pat / GITHUB_PAT or run `gh auth login -h %s`", host, host)
+}
+
+func GetAPIURLhost(apiURL string) (string, string, error) {
+	if apiURL == "" || apiURL == "https://api.github.com" {
+		return "api.github.com", "github.com", nil
+	}
+
+	parsed, err := url.Parse(apiURL)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse target API URL %q: %w", apiURL, err)
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return "", "", fmt.Errorf("could not determine host from target API URL %q", apiURL)
+	}
+
+	// For GHE.com URLs: https://api.<subdomain>.ghe.com
+	//   authHost   = <subdomain>.ghe.com   (for token lookup)
+	//   clientHost = api.<subdomain>.ghe.com (for go-gh client)
+	if strings.HasPrefix(host, "api.") && strings.HasSuffix(host, ".ghe.com") {
+		return host, strings.TrimPrefix(host, "api."), nil
+	}
+
+	return host, host, nil
 }
 
 func formatDateToZ(inputDate string) string {

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -3052,3 +3052,140 @@ func TestHashStringSpecialCharacters(t *testing.T) {
 		hashes[hash] = input
 	}
 }
+
+func TestGetAPIURLhostGHECom(t *testing.T) {
+	testCases := []struct {
+		name         string
+		apiURL       string
+		expectedHost string
+		expectError  bool
+	}{
+		{
+			name:         "Default github.com",
+			apiURL:       "https://api.github.com",
+			expectedHost: "github.com",
+			expectError:  false,
+		},
+		{
+			name:         "GHE.com - octocorp",
+			apiURL:       "https://api.octocorp.ghe.com",
+			expectedHost: "octocorp.ghe.com",
+			expectError:  false,
+		},
+		{
+			name:         "GHE.com - mycompany",
+			apiURL:       "https://api.mycompany.ghe.com",
+			expectedHost: "mycompany.ghe.com",
+			expectError:  false,
+		},
+		{
+			name:         "GHES URL with /api/v3",
+			apiURL:       "https://github.example.com/api/v3",
+			expectedHost: "github.example.com",
+			expectError:  false,
+		},
+		{
+			name:        "Invalid URL",
+			apiURL:      "://invalid-url",
+			expectError: true,
+		},
+		{
+			name:         "Empty URL",
+			apiURL:       "",
+			expectedHost: "github.com",
+			expectError:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, host, err := GetAPIURLhost(tc.apiURL)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedHost, host)
+			}
+		})
+	}
+}
+
+func TestGetGitHubAuthTokenWithTargetAPIURL(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	// Save and clear relevant env vars
+	originalGHPAT := os.Getenv("GITHUB_PAT")
+	defer func() {
+		if originalGHPAT != "" {
+			_ = os.Setenv("GITHUB_PAT", originalGHPAT)
+		} else {
+			_ = os.Unsetenv("GITHUB_PAT")
+		}
+	}()
+	_ = os.Unsetenv("GITHUB_PAT")
+
+	t.Run("Flag PAT takes priority regardless of target API URL", func(t *testing.T) {
+		flags := &data.CmdMigrateFlags{
+			GitHubPAT:    "ghp_flag_token",
+			TargetAPIURL: "https://api.octocorp.ghe.com",
+		}
+
+		token, err := GetGitHubAuthToken(flags, logger)
+		assert.NoError(t, err)
+		assert.Equal(t, "ghp_flag_token", token)
+	})
+
+	t.Run("Environment GITHUB_PAT takes priority over gh CLI", func(t *testing.T) {
+		_ = os.Setenv("GITHUB_PAT", "ghp_env_token")
+		defer func() { _ = os.Unsetenv("GITHUB_PAT") }()
+
+		flags := &data.CmdMigrateFlags{
+			TargetAPIURL: "https://api.octocorp.ghe.com",
+		}
+
+		token, err := GetGitHubAuthToken(flags, logger)
+		assert.NoError(t, err)
+		assert.Equal(t, "ghp_env_token", token)
+	})
+
+	t.Run("No auth returns error with GHE.com host in message", func(t *testing.T) {
+		_ = os.Unsetenv("GITHUB_PAT")
+
+		flags := &data.CmdMigrateFlags{
+			TargetAPIURL: "https://api.octocorp.ghe.com",
+		}
+
+		_, err := GetGitHubAuthToken(flags, logger)
+		// It may find a token via gh CLI keychain, or it may fail.
+		// If it fails, the error should reference the correct host.
+		if err != nil {
+			assert.Contains(t, err.Error(), "octocorp.ghe.com")
+		}
+	})
+
+	t.Run("No auth returns error with github.com host for default URL", func(t *testing.T) {
+		_ = os.Unsetenv("GITHUB_PAT")
+
+		flags := &data.CmdMigrateFlags{
+			TargetAPIURL: "https://api.github.com",
+		}
+
+		_, err := GetGitHubAuthToken(flags, logger)
+		if err != nil {
+			assert.Contains(t, err.Error(), "github.com")
+		}
+	})
+
+	t.Run("Empty target API URL defaults to github.com", func(t *testing.T) {
+		_ = os.Unsetenv("GITHUB_PAT")
+
+		flags := &data.CmdMigrateFlags{
+			TargetAPIURL: "",
+		}
+
+		_, err := GetGitHubAuthToken(flags, logger)
+		if err != nil {
+			assert.Contains(t, err.Error(), "github.com")
+		}
+	})
+}

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -3053,36 +3053,62 @@ func TestHashStringSpecialCharacters(t *testing.T) {
 	}
 }
 
-func TestGetAPIURLhostGHECom(t *testing.T) {
+func TestGetAPIURLHostGHECom(t *testing.T) {
 	testCases := []struct {
-		name         string
-		apiURL       string
-		expectedHost string
-		expectError  bool
+		name            string
+		apiURL          string
+		expectedHost    string
+		expectedAPIHost string
+		expectError     bool
 	}{
 		{
-			name:         "Default github.com",
-			apiURL:       "https://api.github.com",
-			expectedHost: "github.com",
-			expectError:  false,
+			name:            "Default github.com",
+			apiURL:          "https://api.github.com",
+			expectedHost:    "github.com",
+			expectedAPIHost: "api.github.com",
+			expectError:     false,
 		},
 		{
-			name:         "GHE.com - octocorp",
-			apiURL:       "https://api.octocorp.ghe.com",
-			expectedHost: "octocorp.ghe.com",
-			expectError:  false,
+			name:            "GitHub.com with trailing slash",
+			apiURL:          "https://api.github.com/",
+			expectedHost:    "github.com",
+			expectedAPIHost: "api.github.com",
+			expectError:     false,
 		},
 		{
-			name:         "GHE.com - mycompany",
-			apiURL:       "https://api.mycompany.ghe.com",
-			expectedHost: "mycompany.ghe.com",
-			expectError:  false,
+			name:            "GitHub.com with graphql path",
+			apiURL:          "https://api.github.com/graphql",
+			expectedHost:    "github.com",
+			expectedAPIHost: "api.github.com",
+			expectError:     false,
 		},
 		{
-			name:         "GHES URL with /api/v3",
-			apiURL:       "https://github.example.com/api/v3",
-			expectedHost: "github.example.com",
-			expectError:  false,
+			name:            "GitHub.com with v3 path",
+			apiURL:          "https://api.github.com/v3",
+			expectedHost:    "github.com",
+			expectedAPIHost: "api.github.com",
+			expectError:     false,
+		},
+		{
+			name:            "GHE.com - octocorp",
+			apiURL:          "https://api.octocorp.ghe.com",
+			expectedHost:    "octocorp.ghe.com",
+			expectedAPIHost: "api.octocorp.ghe.com",
+			expectError:     false,
+		},
+		{
+			name:            "GHE.com - mycompany",
+			apiURL:          "https://api.mycompany.ghe.com",
+			expectedHost:    "mycompany.ghe.com",
+			expectedAPIHost: "api.mycompany.ghe.com",
+			expectError:     false,
+		},
+		{
+			name:            "GHES URL with /api/v3",
+			apiURL:          "https://github.example.com/api/v3",
+			expectedHost:    "github.example.com",
+			expectedAPIHost: "github.example.com",
+			expectError:     false,
 		},
 		{
 			name:        "Invalid URL",
@@ -3090,21 +3116,23 @@ func TestGetAPIURLhostGHECom(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:         "Empty URL",
-			apiURL:       "",
-			expectedHost: "github.com",
-			expectError:  false,
+			name:            "Empty URL",
+			apiURL:          "",
+			expectedHost:    "github.com",
+			expectedAPIHost: "api.github.com",
+			expectError:     false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, host, err := GetAPIURLhost(tc.apiURL)
+			apiHost, host, err := GetAPIURLHost(tc.apiURL)
 			if tc.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedHost, host)
+				assert.Equal(t, tc.expectedAPIHost, apiHost)
 			}
 		})
 	}

--- a/internal/utils/import.go
+++ b/internal/utils/import.go
@@ -17,16 +17,20 @@ type Getter interface {
 }
 
 type APIGetter struct {
-	gqlClient  api.GraphQLClient
-	restClient api.RESTClient
-	authToken  string
+	gqlClient      api.GraphQLClient
+	restClient     api.RESTClient
+	authToken      string
+	uploadsBaseURL string
+	uploadsHost    string
 }
 
 func NewAPIGetter(gqlClient *api.GraphQLClient, restClient *api.RESTClient, authToken string) *APIGetter {
 	return &APIGetter{
-		gqlClient:  *gqlClient,
-		restClient: *restClient,
-		authToken:  authToken,
+		gqlClient:      *gqlClient,
+		restClient:     *restClient,
+		authToken:      authToken,
+		uploadsBaseURL: defaultUploadsBaseURL,
+		uploadsHost:    defaultUploadsHost,
 	}
 }
 

--- a/internal/utils/import_test.go
+++ b/internal/utils/import_test.go
@@ -806,6 +806,9 @@ func TestGetUploadsBaseURLInvalidURL(t *testing.T) {
 		{"Malformed URL falls back to default", "://not-a-url", false},
 		{"Missing scheme treated as GHES", "api.github.com", true},
 		{"GHES URL is unsupported", "https://github.example.com/api/v3", true},
+		{"GitHub.com with trailing slash", "https://api.github.com/", false},
+		{"GitHub.com with path", "https://api.github.com/graphql", false},
+		{"GitHub.com exact match", "https://api.github.com", false},
 	}
 
 	for _, tc := range testCases {
@@ -818,6 +821,28 @@ func TestGetUploadsBaseURLInvalidURL(t *testing.T) {
 				assert.NotEmpty(t, baseURL, "Base URL should not be empty")
 				assert.NotEmpty(t, host, "Host should not be empty")
 			}
+		})
+	}
+}
+
+func TestGetUploadsBaseURLGitHubComVariants(t *testing.T) {
+	expectedBaseURL := "https://uploads.github.com/organizations/%d/gei/archive"
+	expectedHost := "https://uploads.github.com"
+
+	variants := []string{
+		"",
+		"https://api.github.com",
+		"https://api.github.com/",
+		"https://api.github.com/graphql",
+		"https://api.github.com/v3",
+	}
+
+	for _, apiURL := range variants {
+		t.Run(apiURL, func(t *testing.T) {
+			baseURL, host, err := GetUploadsBaseURL(apiURL)
+			assert.NoError(t, err, "GitHub.com variant should not error: %s", apiURL)
+			assert.Equal(t, expectedBaseURL, baseURL, "Base URL mismatch for: %s", apiURL)
+			assert.Equal(t, expectedHost, host, "Host mismatch for: %s", apiURL)
 		})
 	}
 }

--- a/internal/utils/import_test.go
+++ b/internal/utils/import_test.go
@@ -773,78 +773,23 @@ func TestMigrateGHEComTargetAPIURL(t *testing.T) {
 }
 
 func TestMigrateUploadsURLApplied(t *testing.T) {
-	// Save original values
-	originalBaseURL := uploadsBaseURL
-	originalHost := uploadsHost
-	defer func() {
-		uploadsBaseURL = originalBaseURL
-		uploadsHost = originalHost
-	}()
+	gqlClient := &api.GraphQLClient{}
+	restClient := &api.RESTClient{}
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	targetAPIURL := "https://api.octocorp.ghe.com"
 	newBaseURL, newHost, err := GetUploadsBaseURL(targetAPIURL)
 	assert.NoError(t, err)
 
-	SetUploadsBaseURL(newBaseURL, newHost)
+	apiGetter.SetUploadsBaseURL(newBaseURL, newHost)
 
-	// Verify global state was updated
-	assert.Equal(t, "https://uploads.octocorp.ghe.com/organizations/%d/gei/archive", uploadsBaseURL)
-	assert.Equal(t, "https://uploads.octocorp.ghe.com", uploadsHost)
+	// Verify instance state was updated
+	assert.Equal(t, "https://uploads.octocorp.ghe.com/organizations/%d/gei/archive", apiGetter.uploadsBaseURL)
+	assert.Equal(t, "https://uploads.octocorp.ghe.com", apiGetter.uploadsHost)
 
 	// Verify format string works
-	formatted := fmt.Sprintf(uploadsBaseURL, 99999)
+	formatted := fmt.Sprintf(apiGetter.uploadsBaseURL, 99999)
 	assert.Equal(t, "https://uploads.octocorp.ghe.com/organizations/99999/gei/archive", formatted)
-}
-
-func TestGetUploadsBaseURLInvalidURL(t *testing.T) {
-	testCases := []struct {
-		name        string
-		apiURL      string
-		expectError bool
-	}{
-		{"Empty string returns default", "", false},
-		{"Malformed URL falls back to default", "://not-a-url", false},
-		{"Missing scheme treated as GHES", "api.github.com", true},
-		{"GHES URL is unsupported", "https://github.example.com/api/v3", true},
-		{"GitHub.com with trailing slash", "https://api.github.com/", false},
-		{"GitHub.com with path", "https://api.github.com/graphql", false},
-		{"GitHub.com exact match", "https://api.github.com", false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			baseURL, host, err := GetUploadsBaseURL(tc.apiURL)
-			if tc.expectError {
-				assert.Error(t, err, "Expected error for URL: %s", tc.apiURL)
-			} else {
-				assert.NoError(t, err, "Expected no error for URL: %s", tc.apiURL)
-				assert.NotEmpty(t, baseURL, "Base URL should not be empty")
-				assert.NotEmpty(t, host, "Host should not be empty")
-			}
-		})
-	}
-}
-
-func TestGetUploadsBaseURLGitHubComVariants(t *testing.T) {
-	expectedBaseURL := "https://uploads.github.com/organizations/%d/gei/archive"
-	expectedHost := "https://uploads.github.com"
-
-	variants := []string{
-		"",
-		"https://api.github.com",
-		"https://api.github.com/",
-		"https://api.github.com/graphql",
-		"https://api.github.com/v3",
-	}
-
-	for _, apiURL := range variants {
-		t.Run(apiURL, func(t *testing.T) {
-			baseURL, host, err := GetUploadsBaseURL(apiURL)
-			assert.NoError(t, err, "GitHub.com variant should not error: %s", apiURL)
-			assert.Equal(t, expectedBaseURL, baseURL, "Base URL mismatch for: %s", apiURL)
-			assert.Equal(t, expectedHost, host, "Host mismatch for: %s", apiURL)
-		})
-	}
 }
 
 func TestMigrateHostResolution(t *testing.T) {
@@ -872,7 +817,7 @@ func TestMigrateHostResolution(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, host, err := GetAPIURLhost(tc.targetAPIURL)
+			_, host, err := GetAPIURLHost(tc.targetAPIURL)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedHost, host)
 		})

--- a/internal/utils/import_test.go
+++ b/internal/utils/import_test.go
@@ -726,3 +726,130 @@ func TestSourceRepositoryURLConstruction(t *testing.T) {
 		})
 	}
 }
+
+func TestMigrateGHEComTargetAPIURL(t *testing.T) {
+	testCases := []struct {
+		name            string
+		targetAPIURL    string
+		expectedHost    string
+		expectedBaseURL string
+		expectError     bool
+	}{
+		{
+			name:            "github.com default",
+			targetAPIURL:    "https://api.github.com",
+			expectedHost:    "https://uploads.github.com",
+			expectedBaseURL: "https://uploads.github.com/organizations/%d/gei/archive",
+			expectError:     false,
+		},
+		{
+			name:            "GHE.com octocorp subdomain",
+			targetAPIURL:    "https://api.octocorp.ghe.com",
+			expectedHost:    "https://uploads.octocorp.ghe.com",
+			expectedBaseURL: "https://uploads.octocorp.ghe.com/organizations/%d/gei/archive",
+			expectError:     false,
+		},
+		{
+			name:            "GHE.com custom subdomain",
+			targetAPIURL:    "https://api.myenterprise.ghe.com",
+			expectedHost:    "https://uploads.myenterprise.ghe.com",
+			expectedBaseURL: "https://uploads.myenterprise.ghe.com/organizations/%d/gei/archive",
+			expectError:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseURL, host, err := GetUploadsBaseURL(tc.targetAPIURL)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedBaseURL, baseURL)
+				assert.Equal(t, tc.expectedHost, host)
+			}
+		})
+	}
+}
+
+func TestMigrateUploadsURLApplied(t *testing.T) {
+	// Save original values
+	originalBaseURL := uploadsBaseURL
+	originalHost := uploadsHost
+	defer func() {
+		uploadsBaseURL = originalBaseURL
+		uploadsHost = originalHost
+	}()
+
+	targetAPIURL := "https://api.octocorp.ghe.com"
+	newBaseURL, newHost, err := GetUploadsBaseURL(targetAPIURL)
+	assert.NoError(t, err)
+
+	SetUploadsBaseURL(newBaseURL, newHost)
+
+	// Verify global state was updated
+	assert.Equal(t, "https://uploads.octocorp.ghe.com/organizations/%d/gei/archive", uploadsBaseURL)
+	assert.Equal(t, "https://uploads.octocorp.ghe.com", uploadsHost)
+
+	// Verify format string works
+	formatted := fmt.Sprintf(uploadsBaseURL, 99999)
+	assert.Equal(t, "https://uploads.octocorp.ghe.com/organizations/99999/gei/archive", formatted)
+}
+
+func TestGetUploadsBaseURLInvalidURL(t *testing.T) {
+	testCases := []struct {
+		name        string
+		apiURL      string
+		expectError bool
+	}{
+		{"Empty string returns default", "", false},
+		{"Malformed URL falls back to default", "://not-a-url", false},
+		{"Missing scheme treated as GHES", "api.github.com", true},
+		{"GHES URL is unsupported", "https://github.example.com/api/v3", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseURL, host, err := GetUploadsBaseURL(tc.apiURL)
+			if tc.expectError {
+				assert.Error(t, err, "Expected error for URL: %s", tc.apiURL)
+			} else {
+				assert.NoError(t, err, "Expected no error for URL: %s", tc.apiURL)
+				assert.NotEmpty(t, baseURL, "Base URL should not be empty")
+				assert.NotEmpty(t, host, "Host should not be empty")
+			}
+		})
+	}
+}
+
+func TestMigrateHostResolution(t *testing.T) {
+	testCases := []struct {
+		name         string
+		targetAPIURL string
+		expectedHost string
+	}{
+		{
+			name:         "github.com resolves correctly",
+			targetAPIURL: "https://api.github.com",
+			expectedHost: "github.com",
+		},
+		{
+			name:         "GHE.com resolves subdomain correctly",
+			targetAPIURL: "https://api.octocorp.ghe.com",
+			expectedHost: "octocorp.ghe.com",
+		},
+		{
+			name:         "GHES resolves hostname correctly",
+			targetAPIURL: "https://github.example.com/api/v3",
+			expectedHost: "github.example.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, host, err := GetAPIURLhost(tc.targetAPIURL)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedHost, host)
+		})
+	}
+}

--- a/internal/utils/upload.go
+++ b/internal/utils/upload.go
@@ -17,44 +17,52 @@ import (
 )
 
 var (
-	DefaultPartSize           int64  = 100 * 1024 * 1024  // 100 MB
-	DefaultMultipartThreshold int64  = 5000 * 1024 * 1024 // 5 GB
-	uploadsBaseURL            string = "https://uploads.github.com/organizations/%d/gei/archive"
-	uploadsHost               string = "https://uploads.github.com"
+	DefaultPartSize           int64 = 100 * 1024 * 1024  // 100 MB
+	DefaultMultipartThreshold int64 = 5000 * 1024 * 1024 // 5 GB
+)
+
+const (
+	defaultUploadsBaseURL = "https://uploads.github.com/organizations/%d/gei/archive"
+	defaultUploadsHost    = "https://uploads.github.com"
 )
 
 func GetUploadsBaseURL(targetAPIURL string) (string, string, error) {
 	if targetAPIURL == "" {
-		return "https://uploads.github.com/organizations/%d/gei/archive",
-			"https://uploads.github.com", nil
+		return defaultUploadsBaseURL, defaultUploadsHost, nil
 	}
 
 	parsed, err := url.Parse(targetAPIURL)
 	if err != nil {
-		return uploadsBaseURL, uploadsHost, nil
+		return "", "", fmt.Errorf("failed to parse target API URL %q: %w", targetAPIURL, err)
 	}
 
 	apiHost := parsed.Hostname()
+	if apiHost == "" {
+		return "", "", fmt.Errorf("invalid target API URL: no hostname found in %s", targetAPIURL)
+	}
+
 	if apiHost == "api.github.com" {
-		return "https://uploads.github.com/organizations/%d/gei/archive",
-			"https://uploads.github.com", nil
+		return defaultUploadsBaseURL, defaultUploadsHost, nil
 	}
 
 	// For GHE.com URLs: https://api.<subdomain>.ghe.com
 	// Uploads endpoint: https://uploads.<subdomain>.ghe.com/organizations/%d/gei/archive
 	if strings.HasPrefix(apiHost, "api.") && strings.HasSuffix(apiHost, ".ghe.com") {
+		if parsed.Scheme != "https" {
+			return "", "", fmt.Errorf("target API URL must use HTTPS: %s", targetAPIURL)
+		}
 		gheSubdomain := strings.TrimPrefix(apiHost, "api.")
-		gheUploadsBase := fmt.Sprintf("%s://uploads.%s/organizations/%%d/gei/archive", parsed.Scheme, gheSubdomain)
-		gheUploadsHost := fmt.Sprintf("%s://uploads.%s", parsed.Scheme, gheSubdomain)
+		gheUploadsBase := fmt.Sprintf("https://uploads.%s/organizations/%%d/gei/archive", gheSubdomain)
+		gheUploadsHost := fmt.Sprintf("https://uploads.%s", gheSubdomain)
 		return gheUploadsBase, gheUploadsHost, nil
 	}
 
 	return "", "", fmt.Errorf("invalid or unsupported target API URL: %s", targetAPIURL)
 }
 
-func SetUploadsBaseURL(baseURL, host string) {
-	uploadsBaseURL = baseURL
-	uploadsHost = host
+func (g *APIGetter) SetUploadsBaseURL(baseURL, host string) {
+	g.uploadsBaseURL = baseURL
+	g.uploadsHost = host
 }
 
 func (g *APIGetter) UploadArchiveToGitHub(orgID int, archivePath string, logger *zap.Logger) (string, error) {
@@ -112,7 +120,7 @@ func (g *APIGetter) UploadArchiveToGitHub(orgID int, archivePath string, logger 
 }
 
 func (g *APIGetter) uploadSingleFile(ctx context.Context, orgID int, file *os.File, fileName string, fileSize int64, logger *zap.Logger) (string, error) {
-	uploadURL := fmt.Sprintf("%s?name=%s", fmt.Sprintf(uploadsBaseURL, orgID), url.QueryEscape(fileName))
+	uploadURL := fmt.Sprintf("%s?name=%s", fmt.Sprintf(g.uploadsBaseURL, orgID), url.QueryEscape(fileName))
 
 	logger.Debug("Uploading file in single request",
 		zap.String("url", uploadURL),
@@ -330,7 +338,7 @@ func (g *APIGetter) uploadMultipartFile(ctx context.Context, orgID int, file *os
 }
 
 func (g *APIGetter) startMultipartUpload(ctx context.Context, orgID int, fileName string, fileSize int64, logger *zap.Logger) (string, string, string, error) {
-	uploadURL := fmt.Sprintf("%s/blobs/uploads", fmt.Sprintf(uploadsBaseURL, orgID))
+	uploadURL := fmt.Sprintf("%s/blobs/uploads", fmt.Sprintf(g.uploadsBaseURL, orgID))
 
 	logger.Debug("Preparing multipart upload initiation request",
 		zap.String("url", uploadURL),
@@ -412,7 +420,7 @@ func (g *APIGetter) startMultipartUpload(ctx context.Context, orgID int, fileNam
 }
 
 func (g *APIGetter) uploadPart(ctx context.Context, location string, data []byte, partNumber int, logger *zap.Logger) (string, error) {
-	uploadURL := uploadsHost + location
+	uploadURL := g.uploadsHost + location
 
 	logger.Debug("Uploading part via REST client",
 		zap.Int("partNumber", partNumber),
@@ -464,7 +472,7 @@ func (g *APIGetter) uploadPart(ctx context.Context, location string, data []byte
 }
 
 func (g *APIGetter) completeMultipartUpload(ctx context.Context, lastLocation string, logger *zap.Logger) (string, error) {
-	finalizeURL := uploadsHost + lastLocation
+	finalizeURL := g.uploadsHost + lastLocation
 
 	logger.Debug("Completing multipart upload via REST client",
 		zap.String("finalizeURL", finalizeURL))

--- a/internal/utils/upload.go
+++ b/internal/utils/upload.go
@@ -24,18 +24,21 @@ var (
 )
 
 func GetUploadsBaseURL(targetAPIURL string) (string, string, error) {
-	if targetAPIURL == "" || targetAPIURL == "https://api.github.com" {
+	if targetAPIURL == "" {
 		return "https://uploads.github.com/organizations/%d/gei/archive",
 			"https://uploads.github.com", nil
 	}
 
 	parsed, err := url.Parse(targetAPIURL)
 	if err != nil {
-		// Fall back to default
 		return uploadsBaseURL, uploadsHost, nil
 	}
 
 	apiHost := parsed.Hostname()
+	if apiHost == "api.github.com" {
+		return "https://uploads.github.com/organizations/%d/gei/archive",
+			"https://uploads.github.com", nil
+	}
 
 	// For GHE.com URLs: https://api.<subdomain>.ghe.com
 	// Uploads endpoint: https://uploads.<subdomain>.ghe.com/organizations/%d/gei/archive
@@ -46,7 +49,6 @@ func GetUploadsBaseURL(targetAPIURL string) (string, string, error) {
 		return gheUploadsBase, gheUploadsHost, nil
 	}
 
-	// GHES does not support GEI migrations
 	return "", "", fmt.Errorf("invalid or unsupported target API URL: %s", targetAPIURL)
 }
 

--- a/internal/utils/upload.go
+++ b/internal/utils/upload.go
@@ -23,6 +23,38 @@ var (
 	uploadsHost               string = "https://uploads.github.com"
 )
 
+func GetUploadsBaseURL(targetAPIURL string) (string, string, error) {
+	if targetAPIURL == "" || targetAPIURL == "https://api.github.com" {
+		return "https://uploads.github.com/organizations/%d/gei/archive",
+			"https://uploads.github.com", nil
+	}
+
+	parsed, err := url.Parse(targetAPIURL)
+	if err != nil {
+		// Fall back to default
+		return uploadsBaseURL, uploadsHost, nil
+	}
+
+	apiHost := parsed.Hostname()
+
+	// For GHE.com URLs: https://api.<subdomain>.ghe.com
+	// Uploads endpoint: https://uploads.<subdomain>.ghe.com/organizations/%d/gei/archive
+	if strings.HasPrefix(apiHost, "api.") && strings.HasSuffix(apiHost, ".ghe.com") {
+		gheSubdomain := strings.TrimPrefix(apiHost, "api.")
+		gheUploadsBase := fmt.Sprintf("%s://uploads.%s/organizations/%%d/gei/archive", parsed.Scheme, gheSubdomain)
+		gheUploadsHost := fmt.Sprintf("%s://uploads.%s", parsed.Scheme, gheSubdomain)
+		return gheUploadsBase, gheUploadsHost, nil
+	}
+
+	// GHES does not support GEI migrations
+	return "", "", fmt.Errorf("invalid or unsupported target API URL: %s", targetAPIURL)
+}
+
+func SetUploadsBaseURL(baseURL, host string) {
+	uploadsBaseURL = baseURL
+	uploadsHost = host
+}
+
 func (g *APIGetter) UploadArchiveToGitHub(orgID int, archivePath string, logger *zap.Logger) (string, error) {
 	logger.Debug("Starting archive upload to GitHub",
 		zap.Int("orgID", orgID),

--- a/internal/utils/upload_test.go
+++ b/internal/utils/upload_test.go
@@ -46,9 +46,10 @@ func TestUploadArchiveToGitHub(t *testing.T) {
 	restClient := &api.RESTClient{}
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
-	oldUploadsBaseURL := uploadsBaseURL
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	uri, err := apiGetter.UploadArchiveToGitHub(12345, archivePath, logger)
 
@@ -95,6 +96,10 @@ func TestUploadSingleFile(t *testing.T) {
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	file, err := os.Open(archivePath)
 	assert.NoError(t, err)
@@ -102,10 +107,6 @@ func TestUploadSingleFile(t *testing.T) {
 
 	fileInfo, err := file.Stat()
 	assert.NoError(t, err)
-
-	oldUploadsBaseURL := uploadsBaseURL
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
 
 	ctx := context.Background()
 	uri, err := apiGetter.uploadSingleFile(ctx, 12345, file, "small-archive.tar.gz", fileInfo.Size(), logger)
@@ -169,14 +170,10 @@ func TestUploadMultipartFileIntegration(t *testing.T) {
 
 	gqlClient := &api.GraphQLClient{}
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
-	oldUploadsBaseURL := uploadsBaseURL
-	oldUploadsHost := uploadsHost
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	uploadsHost = testServer.URL
-	defer func() {
-		uploadsBaseURL = oldUploadsBaseURL
-		uploadsHost = oldUploadsHost
-	}()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	oldThreshold := DefaultMultipartThreshold
 	oldPartSize := DefaultPartSize
@@ -223,10 +220,10 @@ func TestStartMultipartUpload(t *testing.T) {
 	assert.NoError(t, err)
 
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
-
-	oldUploadsBaseURL := uploadsBaseURL
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	ctx := context.Background()
 	guid, uploadID, location, err := apiGetter.startMultipartUpload(ctx, 12345, "test-file.tar.gz", 1000000, logger)
@@ -260,10 +257,10 @@ func TestUploadPartIntegration(t *testing.T) {
 	assert.NoError(t, err)
 
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
-
-	oldUploadsHost := uploadsHost
-	uploadsHost = testServer.URL
-	defer func() { uploadsHost = oldUploadsHost }()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	ctx := context.Background()
 	location := "/organizations/12345/gei/archive/blobs/uploads?part_number=1&guid=test-guid-123&upload_id=test-upload-456"
@@ -299,10 +296,10 @@ func TestCompleteMultipartUploadIntegration(t *testing.T) {
 	assert.NoError(t, err)
 
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
-	oldUploadsHost := uploadsHost
-	uploadsHost = testServer.URL
-	defer func() { uploadsHost = oldUploadsHost }()
-
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 	ctx := context.Background()
 	lastLocation := "/organizations/12345/gei/archive/blobs/uploads?part_number=3&guid=test-guid-123&upload_id=test-upload-456"
 	uri, err := apiGetter.completeMultipartUpload(ctx, lastLocation, logger)
@@ -331,10 +328,10 @@ func TestUploadArchiveServerError(t *testing.T) {
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
-
-	oldUploadsBaseURL := uploadsBaseURL
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	_, err = apiGetter.UploadArchiveToGitHub(12345, archivePath, logger)
 
@@ -367,10 +364,10 @@ func TestUploadLargeFileForceMultipart(t *testing.T) {
 	assert.NoError(t, err)
 
 	apiGetter := NewAPIGetter(gqlClient, restClient, "invalid-token-for-test")
-
-	oldUploadsBaseURL := uploadsBaseURL
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	oldThreshold := DefaultMultipartThreshold
 	DefaultMultipartThreshold = 1
@@ -410,10 +407,10 @@ func TestUploadEmptyFile(t *testing.T) {
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
-
-	oldUploadsBaseURL := uploadsBaseURL
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	_, err = apiGetter.UploadArchiveToGitHub(12345, archivePath, logger)
 
@@ -449,10 +446,10 @@ func TestUploadWithMissingToken(t *testing.T) {
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
 	apiGetter := NewAPIGetter(gqlClient, restClient, "")
-
-	oldUploadsBaseURL := uploadsBaseURL
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	_, err = apiGetter.UploadArchiveToGitHub(12345, archivePath, logger)
 
@@ -487,10 +484,10 @@ func TestUploadWithRetry(t *testing.T) {
 	gqlClient := &api.GraphQLClient{}
 	restClient := &api.RESTClient{}
 	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
-
-	oldUploadsBaseURL := uploadsBaseURL
-	uploadsBaseURL = testServer.URL + "/organizations/%d/gei/archive"
-	defer func() { uploadsBaseURL = oldUploadsBaseURL }()
+	apiGetter.SetUploadsBaseURL(
+		testServer.URL+"/organizations/%d/gei/archive",
+		testServer.URL,
+	)
 
 	_, err = apiGetter.UploadArchiveToGitHub(12345, archivePath, logger)
 
@@ -506,18 +503,13 @@ func TestUploadPartSize(t *testing.T) {
 func TestUploadURLConstruction(t *testing.T) {
 	orgID := 12345
 	expectedURL := fmt.Sprintf("https://uploads.github.com/organizations/%d/gei/archive", orgID)
-	actualURL := fmt.Sprintf(uploadsBaseURL, orgID)
+	actualURL := fmt.Sprintf(defaultUploadsBaseURL, orgID)
 	assert.Equal(t, expectedURL, actualURL)
 }
 
 func TestSetUploadsBaseURL(t *testing.T) {
-	// Save original values
-	originalBaseURL := uploadsBaseURL
-	originalHost := uploadsHost
-	defer func() {
-		uploadsBaseURL = originalBaseURL
-		uploadsHost = originalHost
-	}()
+	gqlClient := &api.GraphQLClient{}
+	restClient := &api.RESTClient{}
 
 	testCases := []struct {
 		name            string
@@ -551,29 +543,103 @@ func TestSetUploadsBaseURL(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			SetUploadsBaseURL(tc.baseURL, tc.host)
-			assert.Equal(t, tc.expectedBaseURL, uploadsBaseURL)
-			assert.Equal(t, tc.expectedHost, uploadsHost)
+			apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
+			apiGetter.SetUploadsBaseURL(tc.baseURL, tc.host)
+			assert.Equal(t, tc.expectedBaseURL, apiGetter.uploadsBaseURL)
+			assert.Equal(t, tc.expectedHost, apiGetter.uploadsHost)
 		})
 	}
 }
 
 func TestSetUploadsBaseURLIntegrationWithUpload(t *testing.T) {
-	// Save original values
-	originalBaseURL := uploadsBaseURL
-	originalHost := uploadsHost
-	defer func() {
-		uploadsBaseURL = originalBaseURL
-		uploadsHost = originalHost
-	}()
+	gqlClient := &api.GraphQLClient{}
+	restClient := &api.RESTClient{}
+	apiGetter := NewAPIGetter(gqlClient, restClient, "test-token")
 
 	// Set a GHE.com URL
-	SetUploadsBaseURL(
+	apiGetter.SetUploadsBaseURL(
 		"https://uploads.octocorp.ghe.com/organizations/%d/gei/archive",
 		"https://uploads.octocorp.ghe.com",
 	)
 
 	// Verify the format string works with an org ID
-	result := fmt.Sprintf(uploadsBaseURL, 12345)
+	result := fmt.Sprintf(apiGetter.uploadsBaseURL, 12345)
 	assert.Equal(t, "https://uploads.octocorp.ghe.com/organizations/12345/gei/archive", result)
+}
+
+func TestGetUploadsBaseURLInvalidURL(t *testing.T) {
+	testCases := []struct {
+		name        string
+		apiURL      string
+		expectError bool
+	}{
+		{"Empty string returns default", "", false},
+		{"Malformed URL returns error", "://not-a-url", true},
+		{"Missing scheme treated as GHES", "api.github.com", true},
+		{"GHES URL is unsupported", "https://github.example.com/api/v3", true},
+		{"GitHub.com with trailing slash", "https://api.github.com/", false},
+		{"GitHub.com with path", "https://api.github.com/graphql", false},
+		{"GitHub.com exact match", "https://api.github.com", false},
+		{"Empty hostname in URL", "https:///path", true},
+		{"HTTP GHE.com URL rejected", "http://api.octocorp.ghe.com", true},
+		{"HTTP GitHub.com still returns HTTPS default", "http://api.github.com", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseURL, host, err := GetUploadsBaseURL(tc.apiURL)
+			if tc.expectError {
+				assert.Error(t, err, "Expected error for URL: %s", tc.apiURL)
+			} else {
+				assert.NoError(t, err, "Expected no error for URL: %s", tc.apiURL)
+				assert.NotEmpty(t, baseURL, "Base URL should not be empty")
+				assert.NotEmpty(t, host, "Host should not be empty")
+				// Verify output always uses HTTPS
+				assert.True(t, strings.HasPrefix(baseURL, "https://"),
+					"Base URL should always use HTTPS, got: %s", baseURL)
+				assert.True(t, strings.HasPrefix(host, "https://"),
+					"Host should always use HTTPS, got: %s", host)
+			}
+		})
+	}
+}
+
+func TestGetUploadsBaseURLGitHubComVariants(t *testing.T) {
+	expectedBaseURL := "https://uploads.github.com/organizations/%d/gei/archive"
+	expectedHost := "https://uploads.github.com"
+
+	variants := []string{
+		"",
+		"https://api.github.com",
+		"https://api.github.com/",
+		"https://api.github.com/graphql",
+		"https://api.github.com/v3",
+	}
+
+	for _, apiURL := range variants {
+		t.Run(apiURL, func(t *testing.T) {
+			baseURL, host, err := GetUploadsBaseURL(apiURL)
+			assert.NoError(t, err, "GitHub.com variant should not error: %s", apiURL)
+			assert.Equal(t, expectedBaseURL, baseURL, "Base URL mismatch for: %s", apiURL)
+			assert.Equal(t, expectedHost, host, "Host mismatch for: %s", apiURL)
+		})
+	}
+}
+
+func TestGetUploadsBaseURLRejectsHTTP(t *testing.T) {
+	testCases := []struct {
+		name   string
+		apiURL string
+	}{
+		{"HTTP GHE.com", "http://api.octocorp.ghe.com"},
+		{"HTTP GHE.com with path", "http://api.mycompany.ghe.com/graphql"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := GetUploadsBaseURL(tc.apiURL)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "must use HTTPS")
+		})
+	}
 }

--- a/internal/utils/upload_test.go
+++ b/internal/utils/upload_test.go
@@ -509,3 +509,71 @@ func TestUploadURLConstruction(t *testing.T) {
 	actualURL := fmt.Sprintf(uploadsBaseURL, orgID)
 	assert.Equal(t, expectedURL, actualURL)
 }
+
+func TestSetUploadsBaseURL(t *testing.T) {
+	// Save original values
+	originalBaseURL := uploadsBaseURL
+	originalHost := uploadsHost
+	defer func() {
+		uploadsBaseURL = originalBaseURL
+		uploadsHost = originalHost
+	}()
+
+	testCases := []struct {
+		name            string
+		baseURL         string
+		host            string
+		expectedBaseURL string
+		expectedHost    string
+	}{
+		{
+			name:            "Set GHE.com uploads URL",
+			baseURL:         "https://uploads.octocorp.ghe.com/organizations/%d/gei/archive",
+			host:            "https://uploads.octocorp.ghe.com",
+			expectedBaseURL: "https://uploads.octocorp.ghe.com/organizations/%d/gei/archive",
+			expectedHost:    "https://uploads.octocorp.ghe.com",
+		},
+		{
+			name:            "Set default github.com uploads URL",
+			baseURL:         "https://uploads.github.com/organizations/%d/gei/archive",
+			host:            "https://uploads.github.com",
+			expectedBaseURL: "https://uploads.github.com/organizations/%d/gei/archive",
+			expectedHost:    "https://uploads.github.com",
+		},
+		{
+			name:            "Set custom GHE.com subdomain",
+			baseURL:         "https://uploads.mycompany.ghe.com/organizations/%d/gei/archive",
+			host:            "https://uploads.mycompany.ghe.com",
+			expectedBaseURL: "https://uploads.mycompany.ghe.com/organizations/%d/gei/archive",
+			expectedHost:    "https://uploads.mycompany.ghe.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetUploadsBaseURL(tc.baseURL, tc.host)
+			assert.Equal(t, tc.expectedBaseURL, uploadsBaseURL)
+			assert.Equal(t, tc.expectedHost, uploadsHost)
+		})
+	}
+}
+
+func TestSetUploadsBaseURLIntegrationWithUpload(t *testing.T) {
+	// Save original values
+	originalBaseURL := uploadsBaseURL
+	originalHost := uploadsHost
+	defer func() {
+		uploadsBaseURL = originalBaseURL
+		uploadsHost = originalHost
+	}()
+
+	// Set a GHE.com URL
+	SetUploadsBaseURL(
+		"https://uploads.octocorp.ghe.com/organizations/%d/gei/archive",
+		"https://uploads.octocorp.ghe.com",
+	)
+
+	// Verify the format string works with an org ID
+	result := fmt.Sprintf(uploadsBaseURL, 12345)
+	assert.Equal(t, "https://uploads.octocorp.ghe.com/organizations/12345/gei/archive", result)
+}


### PR DESCRIPTION
### GHE.com Data Residency Migration Support

* Added the `--target-api-url` flag to the `migrate` command, allowing users to specify custom API endpoints for GHE.com instances. The uploads endpoint is automatically derived from the API URL. [[1]](diffhunk://#diff-ac876b4f4f56d82752e72b4a9b6e8c17e8d5546b9c7ebd573062337baefd1fd6R157-R158) [[2]](diffhunk://#diff-ac876b4f4f56d82752e72b4a9b6e8c17e8d5546b9c7ebd573062337baefd1fd6R250-R259) [[3]](diffhunk://#diff-900fcc76b8b35948b441b4df7d80c6f8f590be422fc0d5166e70d9f4bb5e442fR15)
* Updated documentation (`README.md` and `docs/Import-with-gei.md`) to explain how to use the new flag for GHE.com migrations, including examples and endpoint details. GHES is now explicitly marked as unsupported. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L213-R234) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R267-R283) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L377-R406) [[5]](diffhunk://#diff-786c294ee624ce430240ca8c463baeffc1032ec365b25874c7de8b8567105ad0R244-R267)

### Command-Line Flag Validation

* Added validation logic to ensure only supported API URLs (github.com and GHE.com) are accepted; unsupported targets like GHES fail fast before migration starts. [[1]](diffhunk://#diff-ac876b4f4f56d82752e72b4a9b6e8c17e8d5546b9c7ebd573062337baefd1fd6R34-R37) [[2]](diffhunk://#diff-ac876b4f4f56d82752e72b4a9b6e8c17e8d5546b9c7ebd573062337baefd1fd6L63-R73) [[3]](diffhunk://#diff-a9d4f75f71c2767dd9ccb28e0ca034f6cf9a1955614ecae2fc1869ae9e2e4f9dR1214-R1391)

### Testing Enhancements

* Added tests for the new `--target-api-url` flag, including flag existence, default values, serialization, and validation for supported and unsupported targets. Also tests that migration does not start for invalid targets.
* Improved test coverage for command flag handling, descriptions, examples, and authentication priority logic in the export command. [[1]](diffhunk://#diff-6f8ecab7c27720bb07d1d6a19835f411ebefa633e7c6f13408fa436af9371935R39-R47) [[2]](diffhunk://#diff-6f8ecab7c27720bb07d1d6a19835f411ebefa633e7c6f13408fa436af9371935R135-R175) [[3]](diffhunk://#diff-6f8ecab7c27720bb07d1d6a19835f411ebefa633e7c6f13408fa436af9371935R190-R206)

### Documentation and Usability Improvements

* Clarified authentication priority order and updated flag descriptions for export and migrate commands in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L199-R210)
* Added notes to migration documentation about single-step migrations and verifying pull request metadata after migration. [[1]](diffhunk://#diff-786c294ee624ce430240ca8c463baeffc1032ec365b25874c7de8b8567105ad0R8-R12) [[2]](diffhunk://#diff-786c294ee624ce430240ca8c463baeffc1032ec365b25874c7de8b8567105ad0R244-R267)

### Minor Fixes

* Improved assertion messages and subcommand name checks in root command tests.