### PR TITLE
feat: Fall back to merge commit SHA for squash-merged PRs with deleted bran…

### DIFF
--- a/internal/utils/bitbucket.go
+++ b/internal/utils/bitbucket.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/katiem0/gh-bbc-exporter/internal/data"
@@ -26,9 +28,10 @@ type Client struct {
 	username         string // Will be removed after Sept 2025 with appPass
 	appPass          string // To be deprecated Sept 2025
 	logger           *zap.Logger
-	commitSHACache   map[string]string
-	exportDir        string
-	skipCommitLookup bool
+	commitSHACache      map[string]string
+	prSourceCommitCache map[int]string // prID -> original source branch tip SHA
+	exportDir           string
+	skipCommitLookup    bool
 }
 
 func NewClient(baseURL, accessToken, apiToken, email, username, appPass string, logger *zap.Logger, exportDir string, skipCommitLookup bool) *Client {
@@ -66,9 +69,10 @@ func NewClient(baseURL, accessToken, apiToken, email, username, appPass string, 
 		username:         username,
 		appPass:          appPass,
 		logger:           logger,
-		commitSHACache:   make(map[string]string),
-		exportDir:        exportDir,
-		skipCommitLookup: skipCommitLookup,
+		commitSHACache:      make(map[string]string),
+		prSourceCommitCache: make(map[int]string),
+		exportDir:           exportDir,
+		skipCommitLookup:    skipCommitLookup,
 	}
 }
 
@@ -95,6 +99,20 @@ func (c *Client) GetRepository(workspace, repoSlug string) (*data.BitbucketRepos
 	}
 
 	return &repo, nil
+}
+
+func (c *Client) setAuth(req *http.Request) {
+	if c.accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	} else if c.apiToken != "" {
+		if c.email != "" {
+			req.SetBasicAuth(c.email, c.apiToken)
+		} else {
+			req.SetBasicAuth("x-bitbucket-api-token-auth", c.apiToken)
+		}
+	} else if c.username != "" && c.appPass != "" {
+		req.SetBasicAuth(c.username, c.appPass)
+	}
 }
 
 func (c *Client) makeRequest(method, endpoint string, v interface{}) error {
@@ -137,18 +155,7 @@ func (c *Client) makeRequest(method, endpoint string, v interface{}) error {
 			return err
 		}
 
-		if c.accessToken != "" {
-			req.Header.Set("Authorization", "Bearer "+c.accessToken)
-		} else if c.apiToken != "" {
-			if c.email != "" {
-				req.SetBasicAuth(c.email, c.apiToken)
-			} else {
-				req.SetBasicAuth("x-bitbucket-api-token-auth", c.apiToken)
-			}
-		} else if c.username != "" && c.appPass != "" {
-			req.SetBasicAuth(c.username, c.appPass)
-		}
-
+		c.setAuth(req)
 		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := c.httpClient.Do(req)
@@ -442,6 +449,33 @@ func (c *Client) GetPullRequests(workspace, repoSlug string, openPRsOnly bool, p
 				mergeCommitSHA = &fullMergeSHA
 			}
 
+			// For squash-merged PRs with deleted branches, the head SHA may not exist
+			// as a git object in the pack. Fall back to the merge commit SHA so GEI
+			// has a valid commit to show in the Commits tab rather than nothing.
+			if pr.State == "MERGED" && mergeCommitSHA != nil {
+				repoPath := filepath.Join(c.exportDir, "repositories", workspace, repoSlug+".git")
+				if _, statErr := os.Stat(repoPath); statErr != nil {
+					c.logger.Debug("repo path not found, skipping head SHA check",
+						zap.String("repo_path", repoPath),
+						zap.Error(statErr))
+				} else {
+					cmd := exec.Command("git", "cat-file", "-e", headSHA)
+					cmd.Dir = repoPath
+					if err := cmd.Run(); err != nil {
+						c.logger.Debug("head SHA not in pack, falling back to merge commit SHA for PR",
+							zap.Int("pr_id", pr.ID),
+							zap.String("head_sha", headSHA),
+							zap.String("merge_commit_sha", *mergeCommitSHA))
+						headSHA = *mergeCommitSHA
+						// Update the source commit cache so review comments use the same
+						// valid SHA — the original branch tip is not in the pack.
+						if c.prSourceCommitCache != nil {
+							c.prSourceCommitCache[pr.ID] = headSHA
+						}
+					}
+				}
+			}
+
 			// Create the Pull Request with GitHub-compatible structure
 			pullRequest := data.PullRequest{
 				Type:       "pull_request",
@@ -550,6 +584,146 @@ func (c *Client) GetFullCommitSHA(workspace, repoSlug, commitHash string) (strin
 	return commitHash, nil
 }
 
+// GetPullRequestDiff fetches the unified diff for a pull request as raw text.
+func (c *Client) GetPullRequestDiff(workspace, repoSlug string, prID int) (string, error) {
+	fullURL := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d/diff",
+		c.baseURL, workspace, repoSlug, prID)
+
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	c.setAuth(req)
+	req.Header.Set("Accept", "text/plain")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("diff request failed with status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// DiffHunkResult holds the extracted diff hunk and GitHub position for an inline comment.
+type DiffHunkResult struct {
+	Hunk     string
+	Position int
+}
+
+// parseDiffHunk finds the unified diff hunk for a given file path and new-file line number,
+// returning the hunk text and the GitHub position (1-based count from the @@ header line).
+// Returns nil if the file or line cannot be found in the diff.
+func parseDiffHunk(diff, filePath string, targetLine int) *DiffHunkResult {
+	lines := strings.Split(diff, "\n")
+
+	inTargetFile := false
+	var hunkLines []string
+	hunkStarted := false
+	newFileLineNum := 0
+	position := 0
+	targetPosition := -1
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "diff --git ") {
+			if targetPosition != -1 {
+				break
+			}
+			inTargetFile = strings.HasSuffix(line, " b/"+filePath)
+			hunkStarted = false
+			hunkLines = nil
+			newFileLineNum = 0
+			position = 0
+			continue
+		}
+
+		if !inTargetFile {
+			continue
+		}
+
+		if strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ ") ||
+			strings.HasPrefix(line, "index ") || strings.HasPrefix(line, "new file") ||
+			strings.HasPrefix(line, "deleted file") || strings.HasPrefix(line, "similarity") ||
+			strings.HasPrefix(line, "rename") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "@@ ") {
+			if targetPosition != -1 {
+				break
+			}
+			hunkStarted = true
+			hunkLines = []string{line}
+			position = 1
+			newFileLineNum = parseHunkNewStart(line) - 1
+			continue
+		}
+
+		if !hunkStarted {
+			continue
+		}
+
+		hunkLines = append(hunkLines, line)
+		position++
+
+		switch {
+		case strings.HasPrefix(line, "+"):
+			newFileLineNum++
+			if newFileLineNum == targetLine {
+				targetPosition = position
+			}
+		case strings.HasPrefix(line, "-"):
+			// Removed lines don't advance the new file line number
+		default:
+			newFileLineNum++
+			if newFileLineNum == targetLine {
+				targetPosition = position
+			}
+		}
+
+		if targetPosition != -1 {
+			break
+		}
+	}
+
+	if targetPosition == -1 {
+		return nil
+	}
+
+	return &DiffHunkResult{
+		Hunk:     strings.Join(hunkLines, "\n"),
+		Position: targetPosition,
+	}
+}
+
+// parseHunkNewStart extracts the new-file start line number from a unified diff hunk header.
+// e.g. "@@ -10,6 +15,8 @@" returns 15.
+func parseHunkNewStart(hunkHeader string) int {
+	parts := strings.Fields(hunkHeader)
+	for _, part := range parts {
+		if strings.HasPrefix(part, "+") {
+			numPart := strings.TrimPrefix(part, "+")
+			if idx := strings.Index(numPart, ","); idx != -1 {
+				numPart = numPart[:idx]
+			}
+			var n int
+			if _, err := fmt.Sscanf(numPart, "%d", &n); err == nil {
+				return n
+			}
+		}
+	}
+	return 1
+}
+
 func (c *Client) GetPullRequestComments(workspace, repoSlug string, pullRequests []data.PullRequest) ([]data.IssueComment, []data.PullRequestReviewComment, error) {
 	c.logger.Info("Fetching pull request comments")
 
@@ -572,11 +746,48 @@ func (c *Client) GetPullRequestComments(workspace, repoSlug string, pullRequests
 
 	resolvedSHAs := make(map[int]bool)
 	failedPRs := 0
+	prDiffCache := make(map[int]string) // prID -> raw unified diff
+	var prDiffMu sync.Mutex
+	var wg sync.WaitGroup
+
+	for prID := range prURLMap {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			diff, err := c.GetPullRequestDiff(workspace, repoSlug, id)
+			if err != nil {
+				c.logger.Debug("Failed to fetch PR diff, inline comments will be demoted if no diff available",
+					zap.Int("pr_id", id),
+					zap.Error(err))
+				return
+			}
+			prDiffMu.Lock()
+			prDiffCache[id] = diff
+			prDiffMu.Unlock()
+		}(prID)
+	}
+	wg.Wait()
 
 	for prID := range prURLMap {
 		page := 1
 		pageLen := 100
 		hasMore := true
+
+		// Accumulate inline comments whose real diff hunk can't be found,
+		// grouped by thread URL for a single coherent issue comment per thread.
+		type demotedEntry struct {
+			userUUID  string
+			body      string
+			createdAt string
+		}
+		type demotedMeta struct {
+			path           string
+			lineNumber     int
+			firstCommentID int
+			prURL          string
+		}
+		demotedEntries := make(map[string][]demotedEntry) // threadURL -> entries
+		demotedMetas := make(map[string]demotedMeta)      // threadURL -> metadata
 
 		for hasMore {
 			baseEndpoint := fmt.Sprintf("repositories/%s/%s/pullrequests/%d/comments",
@@ -656,35 +867,81 @@ func (c *Client) GetPullRequestComments(workspace, repoSlug string, pullRequests
 					prFullURL := formatURL("pr", workspace, repoSlug, prNumber)
 					userURL := formatURL("user", workspace, "", strings.Trim(comment.User.UUID, "{}"))
 					commitSHA := prCommitMap[prID]
+					prDiff := prDiffCache[prID]
 
-					// Create diff hunk
-					diffHunk := fmt.Sprintf("@@ -0,0 +1,%d @@\n+%s", lineNumber, transformedBody)
+					if prDiff == "" {
+						// No diff available (e.g. squash merge with deleted branch) — demote
+						// the inline review comment to a regular issue comment so it appears
+						// as readable plain text rather than a broken preserved fallback.
+						commentURL := formatURL("issue_comment", workspace, repoSlug, prNumber, comment.ID)
+						prURL := formatURL("pr", workspace, repoSlug, prNumber)
+						demotedBody := fmt.Sprintf("_[Inline comment on `%s` line %d]_\n\n%s",
+							comment.Inline.Path, lineNumber, transformedBody)
+						regularComments = append(regularComments, data.IssueComment{
+							Type:        "issue_comment",
+							URL:         commentURL,
+							User:        userURL,
+							Body:        demotedBody,
+							CreatedAt:   createdAt,
+							Formatter:   "markdown",
+							Reactions:   []string{},
+							PullRequest: prURL,
+						})
+						c.logger.Debug("Demoted inline review comment to issue comment (no diff available)",
+							zap.Int("pr_id", prID),
+							zap.String("path", comment.Inline.Path),
+							zap.Int("line", lineNumber))
+					} else {
+						// Diff is available — extract the real hunk and position.
+						diffHunkResult := parseDiffHunk(prDiff, comment.Inline.Path, lineNumber)
 
-					// Create review comment with correct format
-					reviewComment := data.PullRequestReviewComment{
-						Type:                    "pull_request_review_comment",
-						URL:                     commentURL,
-						PullRequest:             prFullURL,
-						PullRequestReview:       reviewURL,
-						PullRequestReviewThread: threadURL,
-						User:                    userURL,
-						CommitID:                commitSHA,
-						OriginalCommitId:        commitSHA,
-						Path:                    comment.Inline.Path,
-						Position:                lineNumber,
-						OriginalPosition:        lineNumber,
-						Body:                    transformedBody,
-						CreatedAt:               createdAt,
-						UpdatedAt:               updatedAt,
-						Formatter:               "markdown",
-						DiffHunk:                diffHunk,
-						State:                   1,
-						InReplyTo:               inReplyTo,
-						Reactions:               []string{},
-						SubjectType:             "line",
+						if diffHunkResult == nil {
+							// Real hunk not found (e.g. large PR where Bitbucket truncated
+							// the diff). Accumulate into a grouped issue comment per thread.
+							uuid := strings.Trim(comment.User.UUID, "{}")
+							demotedEntries[threadURL] = append(demotedEntries[threadURL], demotedEntry{
+								userUUID:  uuid,
+								body:      transformedBody,
+								createdAt: createdAt,
+							})
+							if _, exists := demotedMetas[threadURL]; !exists {
+								demotedMetas[threadURL] = demotedMeta{
+									path:           comment.Inline.Path,
+									lineNumber:     lineNumber,
+									firstCommentID: comment.ID,
+									prURL:          formatURL("pr", workspace, repoSlug, prNumber),
+								}
+							}
+							c.logger.Debug("Queued inline review comment for grouped demote (hunk not found in diff)",
+								zap.Int("pr_id", prID),
+								zap.String("path", comment.Inline.Path),
+								zap.Int("line", lineNumber))
+						} else {
+							reviewComment := data.PullRequestReviewComment{
+								Type:                    "pull_request_review_comment",
+								URL:                     commentURL,
+								PullRequest:             prFullURL,
+								PullRequestReview:       reviewURL,
+								PullRequestReviewThread: threadURL,
+								User:                    userURL,
+								CommitID:                commitSHA,
+								OriginalCommitId:        commitSHA,
+								Path:                    comment.Inline.Path,
+								Position:                diffHunkResult.Position,
+								OriginalPosition:        diffHunkResult.Position,
+								Body:                    transformedBody,
+								CreatedAt:               createdAt,
+								UpdatedAt:               updatedAt,
+								Formatter:               "markdown",
+								DiffHunk:                diffHunkResult.Hunk,
+								State:                   1,
+								InReplyTo:               inReplyTo,
+								Reactions:               []string{},
+								SubjectType:             "line",
+							}
+							reviewComments = append(reviewComments, reviewComment)
+						}
 					}
-
-					reviewComments = append(reviewComments, reviewComment)
 				} else {
 					commentURL := formatURL("issue_comment", workspace, repoSlug, prNumber, comment.ID)
 					prURL := formatURL("pr", workspace, repoSlug, prNumber)
@@ -709,6 +966,35 @@ func (c *Client) GetPullRequestComments(workspace, repoSlug string, pullRequests
 			if hasMore {
 				page++
 			}
+		}
+
+		// Emit one grouped issue comment per demoted thread
+		for tURL, entries := range demotedEntries {
+			meta := demotedMetas[tURL]
+			var sb strings.Builder
+			sb.WriteString(fmt.Sprintf("_[Inline comment thread on `%s` line %d]_\n\n", meta.path, meta.lineNumber))
+			for _, e := range entries {
+				displayName := e.userUUID
+				if user, ok := c.userCache[e.userUUID]; ok {
+					if user.DisplayName != "" {
+						displayName = user.DisplayName
+					} else if user.Nickname != "" {
+						displayName = user.Nickname
+					}
+				}
+				sb.WriteString(fmt.Sprintf("**%s**: %s\n\n", displayName, e.body))
+			}
+			commentURL := formatURL("issue_comment", workspace, repoSlug, fmt.Sprintf("%d", prID), meta.firstCommentID)
+			regularComments = append(regularComments, data.IssueComment{
+				Type:        "issue_comment",
+				URL:         commentURL,
+				User:        formatURL("user", workspace, "", entries[0].userUUID),
+				Body:        strings.TrimRight(sb.String(), "\n"),
+				CreatedAt:   entries[0].createdAt,
+				Formatter:   "markdown",
+				Reactions:   []string{},
+				PullRequest: meta.prURL,
+			})
 		}
 	}
 

--- a/internal/utils/bitbucket_test.go
+++ b/internal/utils/bitbucket_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -664,6 +665,29 @@ func TestGetPullRequestCommentsWithThreads(t *testing.T) {
                 ],
                 "next": null
             }`))
+		} else if strings.Contains(r.URL.Path, "diff") {
+			// Return a valid unified diff for test/file.txt where line 10 is modified
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "text/plain")
+			diff := "diff --git a/test/file.txt b/test/file.txt\n" +
+				"index abc1234..def5678 100644\n" +
+				"--- a/test/file.txt\n" +
+				"+++ b/test/file.txt\n" +
+				"@@ -1,12 +1,12 @@\n" +
+				" line 1\n" +
+				" line 2\n" +
+				" line 3\n" +
+				" line 4\n" +
+				" line 5\n" +
+				" line 6\n" +
+				" line 7\n" +
+				" line 8\n" +
+				" line 9\n" +
+				"-old line 10\n" +
+				"+new line 10\n" +
+				" line 11\n" +
+				" line 12\n"
+			_, _ = w.Write([]byte(diff))
 		} else {
 			// For commit SHA lookups
 			w.WriteHeader(http.StatusOK)
@@ -1021,12 +1045,13 @@ func TestGetPullRequestCommentsConcurrent(t *testing.T) {
 	elapsed := time.Since(start)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 5, requestCount, "Should make one request per PR")
+	// Each PR now makes 2 requests: one for the diff and one for comments
+	assert.Equal(t, 10, requestCount, "Should make two requests per PR (diff + comments)")
 	assert.Len(t, regularComments, 5, "Should have one comment per PR")
 	assert.Empty(t, reviewComments, "Should have no review comments")
 
-	// Since the current implementation is sequential, expect at least 250ms (5 * 50ms)
-	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond, "Should take at least 5*50ms")
+	// Diffs are fetched in parallel; comments are sequential (5 * 50ms = 250ms minimum)
+	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond, "Should take at least 5*50ms for sequential comment fetching")
 
 	// Log the actual time for debugging
 	t.Logf("Fetching comments for %d PRs took %v", len(prs), elapsed)
@@ -1166,6 +1191,10 @@ func TestGetPullRequestCommentsWithShortSHAs(t *testing.T) {
                 ],
                 "next": null
             }`))
+		} else if strings.Contains(r.URL.Path, "diff") {
+			// Return a minimal valid diff so inline comments are not demoted
+			w.WriteHeader(http.StatusOK)
+			writeResponse(t, w, []byte("diff --git a/test.txt b/test.txt\nindex 0000000..1234567 100644\n--- a/test.txt\n+++ b/test.txt\n@@ -0,0 +1,10 @@\n+line 1\n+line 2\n+line 3\n+line 4\n+line 5\n+line 6\n+line 7\n+line 8\n+line 9\n+line 10\n"))
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -1203,5 +1232,281 @@ func TestGetPullRequestCommentsWithShortSHAs(t *testing.T) {
 
 	for _, comment := range regularComments {
 		assert.Equal(t, "https://bitbucket.org/workspace/repo/pull/1", comment.PullRequest)
+	}
+}
+
+// TestGetPullRequestsSquashMergeHeadSHAFallback verifies that when a squash-merged PR's
+// head SHA does not exist as a git object in the local pack (branch was deleted after merge),
+// the head SHA is replaced with the merge commit SHA so GEI has a valid object to reference.
+func TestGetPullRequestsSquashMergeHeadSHAFallback(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	// Build the directory structure the production code expects:
+	// exportDir/repositories/workspace/repo.git
+	exportDir := t.TempDir()
+	repoDir := filepath.Join(exportDir, "repositories", "workspace", "repo.git")
+	assert.NoError(t, os.MkdirAll(repoDir, 0755))
+
+	// Create a regular repo, make a commit, then clone it as bare into the expected path.
+	// git commit doesn't work directly on a bare repo, so we use a temp working tree.
+	workDir := t.TempDir()
+	gitEnv := append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+
+	for _, step := range []struct {
+		args []string
+		dir  string
+	}{
+		{[]string{"init", workDir}, ""},
+		{[]string{"commit", "--allow-empty", "-m", "initial"}, workDir},
+		{[]string{"clone", "--bare", workDir, repoDir}, ""},
+	} {
+		cmd := exec.Command("git", step.args...)
+		cmd.Dir = step.dir
+		cmd.Env = gitEnv
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %s: %v", step.args, out, err)
+		}
+	}
+
+	// Get the real commit SHA that exists in the bare repo
+	cmd := exec.Command("git", "--git-dir", repoDir, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	assert.NoError(t, err)
+	existingSHA := strings.TrimSpace(string(out))
+	assert.Len(t, existingSHA, 40)
+
+	// A SHA that definitely does not exist in the repo
+	missingSHA := strings.Repeat("a", 40)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Return two merged PRs:
+		//   PR 1: head SHA exists in pack (regular merge or squash with branch kept)
+		//   PR 2: head SHA does NOT exist in pack (squash merge, branch deleted)
+		// Both have a merge_commit that points to existingSHA.
+		writeResponse(t, w, []byte(`{
+			"values": [
+				{
+					"id": 1,
+					"title": "Regular merge PR",
+					"state": "MERGED",
+					"updated_on": "2024-01-01T00:00:00+00:00",
+					"created_on": "2024-01-01T00:00:00+00:00",
+					"author": {"uuid": "{test-uuid}"},
+					"source":      {"branch": {"name": "feature"}, "commit": {"hash": "`+existingSHA+`"}},
+					"destination": {"branch": {"name": "main"},    "commit": {"hash": "`+existingSHA+`"}},
+					"merge_commit": {"hash": "`+existingSHA+`"}
+				},
+				{
+					"id": 2,
+					"title": "Squash merge PR - branch deleted",
+					"state": "MERGED",
+					"updated_on": "2024-01-02T00:00:00+00:00",
+					"created_on": "2024-01-02T00:00:00+00:00",
+					"author": {"uuid": "{test-uuid}"},
+					"source":      {"branch": {"name": "squash-branch"}, "commit": {"hash": "`+missingSHA+`"}},
+					"destination": {"branch": {"name": "main"},          "commit": {"hash": "`+existingSHA+`"}},
+					"merge_commit": {"hash": "`+existingSHA+`"}
+				}
+			],
+			"next": null
+		}`))
+	}))
+	defer testServer.Close()
+
+	client := &Client{
+		baseURL:        testServer.URL,
+		httpClient:     testServer.Client(),
+		logger:         logger,
+		commitSHACache: make(map[string]string),
+		exportDir:      exportDir,
+	}
+
+	prs, err := client.GetPullRequests("workspace", "repo", false, "")
+	assert.NoError(t, err)
+	assert.Len(t, prs, 2)
+
+	// PR 1: head SHA exists in pack — should be unchanged
+	assert.Equal(t, existingSHA, prs[0].Head.SHA,
+		"PR with existing head SHA should not be modified")
+
+	// PR 2: head SHA missing from pack — should fall back to merge commit SHA
+	assert.Equal(t, existingSHA, prs[1].Head.SHA,
+		"PR with missing head SHA should fall back to merge commit SHA")
+	assert.NotEqual(t, missingSHA, prs[1].Head.SHA,
+		"Missing head SHA should not be retained")
+}
+
+func TestParseHunkNewStart(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		expected int
+	}{
+		{
+			name:     "standard hunk header",
+			header:   "@@ -10,6 +15,8 @@",
+			expected: 15,
+		},
+		{
+			name:     "new file starting at line 1",
+			header:   "@@ -0,0 +1,5 @@",
+			expected: 1,
+		},
+		{
+			name:     "no comma in new-file range",
+			header:   "@@ -1 +1 @@",
+			expected: 1,
+		},
+		{
+			name:     "hunk header with function context",
+			header:   "@@ -10,6 +15,8 @@ func foo() {",
+			expected: 15,
+		},
+		{
+			name:     "first line of file",
+			header:   "@@ -1,3 +1,3 @@",
+			expected: 1,
+		},
+		{
+			name:     "empty string falls back to 1",
+			header:   "",
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseHunkNewStart(tt.header))
+		})
+	}
+}
+
+func TestParseDiffHunk(t *testing.T) {
+	// A simple two-file diff used across several cases.
+	simpleDiff := strings.Join([]string{
+		"diff --git a/foo.go b/foo.go",
+		"index 0000001..0000002 100644",
+		"--- a/foo.go",
+		"+++ b/foo.go",
+		"@@ -1,4 +1,5 @@",
+		" line1",
+		" line2",
+		"+added line",
+		" line3",
+		" line4",
+		"diff --git a/bar.go b/bar.go",
+		"index 0000003..0000004 100644",
+		"--- a/bar.go",
+		"+++ b/bar.go",
+		"@@ -1,3 +1,3 @@",
+		" alpha",
+		"-removed",
+		"+replaced",
+		" beta",
+	}, "\n")
+
+	tests := []struct {
+		name             string
+		diff             string
+		filePath         string
+		targetLine       int
+		expectNil        bool
+		expectedPosition int
+		expectHunkPrefix string // @@ header the hunk should start with
+	}{
+		{
+			name:             "added line matched",
+			diff:             simpleDiff,
+			filePath:         "foo.go",
+			targetLine:       3, // "+added line" is the 3rd new-file line
+			expectedPosition: 4, // position 1=@@, 2=line1, 3=line2, 4=+added line
+			expectHunkPrefix: "@@ -1,4 +1,5 @@",
+		},
+		{
+			name:             "context line matched",
+			diff:             simpleDiff,
+			filePath:         "foo.go",
+			targetLine:       4, // " line3" is the 4th new-file line
+			expectedPosition: 5,
+			expectHunkPrefix: "@@ -1,4 +1,5 @@",
+		},
+		{
+			name:             "replaced line in second file",
+			diff:             simpleDiff,
+			filePath:         "bar.go",
+			targetLine:       2, // "+replaced" is the 2nd new-file line
+			expectedPosition: 4, // position 1=@@, 2=alpha, 3=-removed, 4=+replaced
+			expectHunkPrefix: "@@ -1,3 +1,3 @@",
+		},
+		{
+			name:      "file not in diff returns nil",
+			diff:      simpleDiff,
+			filePath:  "missing.go",
+			targetLine: 1,
+			expectNil: true,
+		},
+		{
+			name:      "target line beyond end of hunk returns nil",
+			diff:      simpleDiff,
+			filePath:  "foo.go",
+			targetLine: 99,
+			expectNil: true,
+		},
+		{
+			name: "multi-hunk file: target in second hunk",
+			diff: strings.Join([]string{
+				"diff --git a/multi.go b/multi.go",
+				"index 0000001..0000002 100644",
+				"--- a/multi.go",
+				"+++ b/multi.go",
+				"@@ -1,3 +1,3 @@",
+				" a",
+				"-old",
+				"+new",
+				"@@ -10,3 +10,4 @@",
+				" x",
+				"+inserted",
+				" y",
+				" z",
+			}, "\n"),
+			filePath:         "multi.go",
+			targetLine:       11, // "+inserted" is new-file line 11
+			expectedPosition: 3,  // position 1=@@, 2=x, 3=+inserted
+			expectHunkPrefix: "@@ -10,3 +10,4 @@",
+		},
+		{
+			name: "deleted-only hunk has no new-file lines for target",
+			diff: strings.Join([]string{
+				"diff --git a/gone.go b/gone.go",
+				"index 0000001..0000002 100644",
+				"--- a/gone.go",
+				"+++ b/gone.go",
+				"@@ -1,3 +0,0 @@",
+				"-line1",
+				"-line2",
+				"-line3",
+			}, "\n"),
+			filePath:   "gone.go",
+			targetLine: 1,
+			expectNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDiffHunk(tt.diff, tt.filePath, tt.targetLine)
+			if tt.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+			assert.NotNil(t, result)
+			assert.Equal(t, tt.expectedPosition, result.Position)
+			assert.True(t, strings.HasPrefix(result.Hunk, tt.expectHunkPrefix),
+				"hunk should start with %q, got %q", tt.expectHunkPrefix, result.Hunk)
+		})
 	}
 }


### PR DESCRIPTION
When a PR is merged using squash merge and the source branch is subsequently deleted, the original feature branch commits are no longer reachable via any git ref in the mirror clone. The head.sha field in the exported PR points to the branch tip SHA, but that object doesn't exist in the pack, leaving the Commits tab empty in GitHub after migration.

This change adds a fallback in GetPullRequests: after resolving head.sha, it checks whether that object exists in the local bare repo using git cat-file -e. If the object is missing and a merge commit SHA is available, it substitutes the merge commit SHA instead.

**Result:**

- Regular merge PRs — unchanged, head.sha stays as the branch tip
- Squash merge, branch kept — unchanged, branch tip object exists in pack
- Squash merge, branch deleted — head.sha falls back to merge commit SHA, GEI shows the single squash commit in the Commits tab rather than nothing