### PR TITLE
Addressing nulls for GHES

### DIFF
--- a/internal/data/ghdata.go
+++ b/internal/data/ghdata.go
@@ -98,7 +98,7 @@ type Repository struct {
 	CreatedAt              string                 `json:"created_at"`
 	GitURL                 string                 `json:"git_url"`
 	DefaultBranch          string                 `json:"default_branch"`
-	WikiURL                string                 `json:"wiki_url"`
+	WikiURL                *string                `json:"wiki_url"`
 	PublicKeys             []interface{}          `json:"public_keys"`
 	RepositoryTopics       []interface{}          `json:"repository_topics,omitempty"`
 	SecurityAndAnalysis    map[string]interface{} `json:"security_and_analysis,omitempty"`

--- a/internal/data/ghddata_test.go
+++ b/internal/data/ghddata_test.go
@@ -160,3 +160,50 @@ func TestCmdExportFlagsDefaults(t *testing.T) {
 	assert.Empty(t, flags.BitbucketAppPass)
 	assert.Empty(t, flags.BitbucketAPIURL)
 }
+func TestUserEmailsMarshalsAsEmptyArrayNotNull(t *testing.T) {
+	u := User{
+		Type:   "user",
+		Login:  "alice",
+		Name:   "Alice",
+		Emails: []Email{},
+	}
+	b, err := json.Marshal(u)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"emails":[]`,
+		"emails must serialize as [] so the GHE migrator can call .find on it")
+	assert.NotContains(t, string(b), `"emails":null`)
+}
+
+func TestUserEmailsNilMarshalsAsNull(t *testing.T) {
+	// Guard test: documents the bug behavior we're avoiding.
+	u := User{Type: "user", Login: "alice", Emails: nil}
+	b, err := json.Marshal(u)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"emails":null`,
+		"sanity check: nil slice still serializes to null in Go")
+}
+
+func TestRepositoryWikiURLNilMarshalsAsNull(t *testing.T) {
+	r := Repository{Type: "repository", Name: "r", Slug: "r"}
+	b, err := json.Marshal(r)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"wiki_url":null`,
+		"wiki_url must be null when unset so the GHE migrator skips wiki import")
+	assert.NotContains(t, string(b), `"wiki_url":""`)
+}
+
+func TestRepositoryWikiURLPointerWhenSet(t *testing.T) {
+	s := "https://example.com/wiki.tar.gz"
+	r := Repository{Type: "repository", Name: "r", Slug: "r", WikiURL: &s}
+	b, err := json.Marshal(r)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"wiki_url":"https://example.com/wiki.tar.gz"`)
+}
+
+func TestRepositoryWikiURLRoundTripNull(t *testing.T) {
+	in := []byte(`{"type":"repository","name":"r","slug":"r","wiki_url":null}`)
+	var r Repository
+	err := json.Unmarshal(in, &r)
+	assert.NoError(t, err)
+	assert.Nil(t, r.WikiURL)
+}

--- a/internal/data/ghddata_test.go
+++ b/internal/data/ghddata_test.go
@@ -174,15 +174,6 @@ func TestUserEmailsMarshalsAsEmptyArrayNotNull(t *testing.T) {
 	assert.NotContains(t, string(b), `"emails":null`)
 }
 
-func TestUserEmailsNilMarshalsAsNull(t *testing.T) {
-	// Guard test: documents the bug behavior we're avoiding.
-	u := User{Type: "user", Login: "alice", Emails: nil}
-	b, err := json.Marshal(u)
-	assert.NoError(t, err)
-	assert.Contains(t, string(b), `"emails":null`,
-		"sanity check: nil slice still serializes to null in Go")
-}
-
 func TestRepositoryWikiURLNilMarshalsAsNull(t *testing.T) {
 	r := Repository{Type: "repository", Name: "r", Slug: "r"}
 	b, err := json.Marshal(r)

--- a/internal/utils/bitbucket.go
+++ b/internal/utils/bitbucket.go
@@ -238,7 +238,7 @@ func (c *Client) GetUsers(workspace, repoSlug string) ([]data.User, error) {
 					Company:   nil,
 					Website:   nil,
 					Location:  nil,
-					Emails:    nil,
+					Emails:    []data.Email{},
 					CreatedAt: formatDateToZ(time.Now().Format(time.RFC3339)),
 				},
 			}, nil
@@ -257,7 +257,7 @@ func (c *Client) GetUsers(workspace, repoSlug string) ([]data.User, error) {
 				Company:   nil,
 				Website:   nil,
 				Location:  nil,
-				Emails:    nil,
+				Emails:    []data.Email{},
 				CreatedAt: formatDateToZ(time.Now().Format(time.RFC3339)),
 			}
 
@@ -279,7 +279,7 @@ func (c *Client) GetUsers(workspace, repoSlug string) ([]data.User, error) {
 			Company:   nil,
 			Website:   nil,
 			Location:  nil,
-			Emails:    nil,
+			Emails:    []data.Email{},
 			CreatedAt: formatDateToZ(time.Now().Format(time.RFC3339)),
 		})
 	}

--- a/internal/utils/bitbucket_test.go
+++ b/internal/utils/bitbucket_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/katiem0/gh-bbc-exporter/internal/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -1203,5 +1205,66 @@ func TestGetPullRequestCommentsWithShortSHAs(t *testing.T) {
 
 	for _, comment := range regularComments {
 		assert.Equal(t, "https://bitbucket.org/workspace/repo/pull/1", comment.PullRequest)
+	}
+}
+
+// TestGetUsersAlwaysEmitsEmptyEmailsArray pins the fix for the GHE migrator's
+// `users.emails.find(...)` NoMethodError: every data.User construction path in
+// GetUsers must produce JSON with `"emails":[]`, never `"emails":null`.
+func TestGetUsersAlwaysEmitsEmptyEmailsArray(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "members loop",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				writeResponse(t, w, []byte(`{"values":[{"user":{"display_name":"Test User","uuid":"{test-uuid}"}}],"next":null}`))
+			},
+		},
+		{
+			name: "empty members fallback",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				writeResponse(t, w, []byte(`{"values":[],"next":null}`))
+			},
+		},
+		{
+			name: "api error fallback",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				writeResponse(t, w, []byte(`{"error":"boom"}`))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			logger, _ := zap.NewDevelopment()
+			client := &Client{
+				baseURL:        srv.URL,
+				httpClient:     srv.Client(),
+				logger:         logger,
+				commitSHACache: make(map[string]string),
+			}
+
+			users, err := client.GetUsers("workspace", "repo")
+			assert.NoError(t, err)
+			require.NotEmpty(t, users)
+
+			for _, u := range users {
+				assert.NotNil(t, u.Emails,
+					"Emails must be non-nil so JSON serializes as [] (GHE migrator calls .find on it)")
+			}
+
+			b, err := json.Marshal(users)
+			assert.NoError(t, err)
+			assert.Contains(t, string(b), `"emails":[]`)
+			assert.NotContains(t, string(b), `"emails":null`)
+		})
 	}
 }

--- a/internal/utils/exporter_test.go
+++ b/internal/utils/exporter_test.go
@@ -504,6 +504,35 @@ func TestCreateBasicUsers_Fallback(t *testing.T) {
 	assert.Equal(t, "user", users[0].Type)
 	assert.Equal(t, "ws-fallback", users[0].Login)
 	assert.Equal(t, "ws-fallback", users[0].Name)
+
+	// Pins the fix for the GHE migrator's users.emails.find(...) NoMethodError:
+	// the basic-users fallback must serialize emails as [], not null.
+	assert.NotNil(t, users[0].Emails, "Emails must be non-nil so JSON serializes as []")
+	b, err := json.Marshal(users)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"emails":[]`)
+	assert.NotContains(t, string(b), `"emails":null`)
+}
+
+// TestCreateRepositoriesDataEmitsWikiURLNull pins the fix for the GHE migrator's
+// InvalidTarballUrl on wiki import: an unset wiki_url must serialize as null
+// (falsy in Ruby) so the migrator skips the wiki-import branch entirely.
+func TestCreateRepositoriesDataEmitsWikiURLNull(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	exporter := NewExporter(&Client{}, "", logger, false, "")
+
+	repos := exporter.createRepositoriesData(&data.BitbucketRepository{
+		Name:      "r",
+		Slug:      "r",
+		CreatedOn: "2024-01-01T00:00:00+00:00",
+	}, "ws")
+	assert.Len(t, repos, 1)
+	assert.Nil(t, repos[0].WikiURL, "WikiURL must be nil so it serializes as null")
+
+	b, err := json.Marshal(repos)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"wiki_url":null`)
+	assert.NotContains(t, string(b), `"wiki_url":""`)
 }
 
 func TestUpdateRepositoryField(t *testing.T) {

--- a/internal/utils/exporter_test.go
+++ b/internal/utils/exporter_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/katiem0/gh-bbc-exporter/internal/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -518,7 +519,9 @@ func TestCreateBasicUsers_Fallback(t *testing.T) {
 // InvalidTarballUrl on wiki import: an unset wiki_url must serialize as null
 // (falsy in Ruby) so the migrator skips the wiki-import branch entirely.
 func TestCreateRepositoriesDataEmitsWikiURLNull(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	defer func() { _ = logger.Sync() }()
 	exporter := NewExporter(&Client{}, "", logger, false, "")
 
 	repos := exporter.createRepositoriesData(&data.BitbucketRepository{

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -858,11 +858,14 @@ func TestUpdateRepositoryFieldPreservesWikiURLNull(t *testing.T) {
 	b, err := os.ReadFile(filepath.Join(tempDir, "repositories_000001.json"))
 	assert.NoError(t, err)
 
-	// Field must still serialize as null (string match, not unmarshal, since the
-	// migrator consumes the raw JSON).
-	assert.Contains(t, string(b), `"wiki_url": null`,
+	// Normalize JSON so the assertion is whitespace-insensitive (the migrator
+	// consumes raw JSON regardless of indentation).
+	var compact bytes.Buffer
+	assert.NoError(t, json.Compact(&compact, b))
+
+	assert.Contains(t, compact.String(), `"wiki_url":null`,
 		"wiki_url must remain null after round-trip through updateRepositoryField")
-	assert.NotContains(t, string(b), `"wiki_url": ""`)
+	assert.NotContains(t, compact.String(), `"wiki_url":""`)
 
 	var repos []data.Repository
 	assert.NoError(t, json.Unmarshal(b, &repos))

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -827,6 +827,49 @@ func TestGetOutputPath(t *testing.T) {
 	assert.Equal(t, "", path, "Empty output dir should remain empty until Export() is called")
 }
 
+// TestUpdateRepositoryFieldPreservesWikiURLNull guards the GHE migrator wiki-import
+// fix at the disk round-trip layer: editing repositories_000001.json (e.g. to
+// update default_branch) must not silently turn `"wiki_url":null` into
+// `"wiki_url":""`, which would re-trigger InvalidTarballUrl.
+func TestUpdateRepositoryFieldPreservesWikiURLNull(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "update-repo-field-wiki-")
+	assert.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	logger, _ := zap.NewDevelopment()
+	exporter := NewExporter(&Client{}, tempDir, logger, false, "")
+
+	// Seed with WikiURL nil (the only state we ever produce post-fix).
+	initial := []data.Repository{
+		{
+			Type:          "repository",
+			Name:          "r",
+			Slug:          "r",
+			DefaultBranch: "main",
+			WikiURL:       nil,
+		},
+	}
+	err = exporter.writeJSONFile("repositories_000001.json", initial)
+	assert.NoError(t, err)
+
+	exporter.updateRepositoryField("r", "default_branch", "develop")
+	exporter.updateRepositoryField("r", "git_url", "tarball://root/repositories/ws/r.git")
+
+	b, err := os.ReadFile(filepath.Join(tempDir, "repositories_000001.json"))
+	assert.NoError(t, err)
+
+	// Field must still serialize as null (string match, not unmarshal, since the
+	// migrator consumes the raw JSON).
+	assert.Contains(t, string(b), `"wiki_url": null`,
+		"wiki_url must remain null after round-trip through updateRepositoryField")
+	assert.NotContains(t, string(b), `"wiki_url": ""`)
+
+	var repos []data.Repository
+	assert.NoError(t, json.Unmarshal(b, &repos))
+	assert.Nil(t, repos[0].WikiURL)
+	assert.Equal(t, "develop", repos[0].DefaultBranch)
+}
+
 func TestUpdateRepositoryFieldCaseInsensitive(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "update-repo-field-case-")
 	assert.NoError(t, err)


### PR DESCRIPTION
This pull request fixes serialization issues for `emails` in `User` objects and `wiki_url` in `Repository` objects to ensure compatibility with the GHE migrator, which expects `emails` to always be an empty array (not `null`) and `wiki_url` to be `null` (not an empty string) when unset. It also adds comprehensive tests to pin these behaviors and prevent regressions.
This pull request addresses serialization issues to improve compatibility with the GitHub Enterprise (GHE) migrator, specifically ensuring that JSON output for users and repositories is consistent and avoids runtime errors during migration. The most important changes enforce that user `Emails` fields always serialize as empty arrays (`[]`) rather than `null`, and that repository `WikiURL` fields serialize as `null` when unset, never as empty strings. Several tests are added to pin these behaviors and prevent regressions.

**Serialization fixes for GHE migrator compatibility:**

* Changed the `Repository.WikiURL` field to a pointer (`*string`), so it serializes as `null` when unset, ensuring the GHE migrator skips wiki import if no wiki URL is present.
* Updated all `GetUsers` code paths to always set `User.Emails` to an empty slice (`[]data.Email{}`), so it serializes as `[]` and never as `null`, preventing `NoMethodError` in the migrator. [[1]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL241-R241) [[2]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL260-R260) [[3]](diffhunk://#diff-025880258080bd1bee5b1090203102e4cada3b1905bfe446d80608fb798db22dL282-R282)

**Test coverage and regression prevention:**

* Added tests to verify that `User.Emails` serializes as `[]` (never `null`), and that `Repository.WikiURL` serializes as `null` when unset, including round-trip tests to ensure this behavior is preserved during file updates. [[1]](diffhunk://#diff-da1cfaf4818f09fd05dd362d208a299d8c4706b5f2f5f9403dcffe6203709a8cR163-R209) [[2]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52R1210-R1270) [[3]](diffhunk://#diff-c7d6728e28949a1a3493a8faf7afcb5fd257683e68e0abf02dde70b8a68e0b88R507-R535) [[4]](diffhunk://#diff-18297b8f134ac29310e8b487eaa0bc0647fee4c8f5abdf53600efc6565eef5a0R830-R872)
* Added and improved imports in test files for better assertion and test reliability. [[1]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52R4) [[2]](diffhunk://#diff-7dc8b4afc48ae8939094b912a858f747ab05750594cd4a5dd19719fbc5bb4e52R17)

These changes ensure that exported data is reliably consumed by the GHE migrator, preventing known errors related to JSON structure.